### PR TITLE
ci: auto-publish Android to Play internal testing

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,6 +1,9 @@
 name: Android Build
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       android_version_code:
@@ -8,15 +11,17 @@ on:
         required: false
         type: string
       version_label:
-        description: "Version label"
+        description: "Version label (defaults to package.json version)"
         required: false
         type: string
 
-concurrency: android-build
+concurrency:
+  group: android-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-android:
-    name: Build Android
+    name: Build Android & Upload to Internal
     runs-on: ubuntu-latest
 
     steps:
@@ -53,27 +58,33 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      - name: Resolve version label
+        id: version
+        run: |
+          INPUT_LABEL="${{ github.event.inputs.version_label }}"
+          if [ -n "$INPUT_LABEL" ]; then
+            LABEL="$INPUT_LABEL"
+          else
+            LABEL="$(node -p "require('./package.json').version")"
+          fi
+          echo "Using version label: $LABEL"
+          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
+
       - name: Decode Android keystore
         run: |
           mkdir -p android/app
-          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.jks
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.jks
 
       - name: Run Fastlane Android build
         env:
           ANDROID_VERSION_CODE: ${{ github.event.inputs.android_version_code || github.run_number }}
-          VERSION_LABEL: ${{ github.event.inputs.version_label }}
+          VERSION_LABEL: ${{ steps.version.outputs.label }}
           ANDROID_KEYSTORE_PATH: release.jks
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.ANDROID_SERVICE_ACCOUNT }}
         run: bundle exec fastlane android ci_android
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: yuzic-android-apk
-          path: android/app/build/outputs/**/*.apk
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -97,7 +97,7 @@ android {
 
     namespace 'com.arinora.rawarr'
     defaultConfig {
-        applicationId 'com.arinora.rawarr'
+        applicationId 'com.gamesbyjerry.yuzic'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode resolvedVersionCode

--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
         "android.permission.RECORD_AUDIO",
         "android.permission.MODIFY_AUDIO_SETTINGS"
       ],
-      "package": "com.arinora.rawarr"
+      "package": "com.gamesbyjerry.yuzic"
     },
     "web": {
       "bundler": "metro",

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,4 +1,4 @@
 json_key_file(ENV["PLAY_STORE_KEY"])
-package_name("com.arinora.rawarr") # e.g. com.krausefx.app
-app_identifier("com.arinora.rawarr")
+package_name("com.gamesbyjerry.yuzic") # Android / Play Store app id
+app_identifier("com.arinora.rawarr") # iOS / App Store bundle id (unchanged)
 apple_id(ENV["APPLE_ID"])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,7 +69,8 @@ platform :android do
     )
 
     supply(
-      track: "alpha",
+      track: "internal",
+      package_name: "com.gamesbyjerry.yuzic",
       aab: "android/app/build/outputs/bundle/release/app-release.aab",
       json_key_data: ENV["GOOGLE_PLAY_JSON_KEY"],
       skip_upload_apk: true,


### PR DESCRIPTION
## What
Make the Android pipeline **auto-build on push to `master`** and upload to the **Play internal testing** track for the new GamesByJerry listing — mirroring the MyHome CI flow.

## Changes
- **Package id** → `com.gamesbyjerry.yuzic` (`android/app/build.gradle` `applicationId`, `app.json` `android.package`). `namespace` and the native source package are left as-is (internal R-class only). **iOS / App Store untouched.**
- **Fastfile**: `supply` track `alpha` → `internal`, `package_name` pinned.
- **Appfile**: Play `package_name` → new id; iOS `app_identifier` unchanged.
- **Workflow** (`android-build.yml`): triggers on **push to `master`** (+ `workflow_dispatch`); wired to the secrets present in this repo (`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, `ANDROID_SERVICE_ACCOUNT`); version label from `package.json`, `versionCode` from the run number.

## Before the first run succeeds
1. Confirm `ANDROID_SERVICE_ACCOUNT` has access to `com.gamesbyjerry.yuzic` in Play Console → Users & permissions.
2. Google usually rejects the **first** AAB via API — upload the first bundle manually + complete app-content setup, then CI takes over.

## Signing
Reuses existing `KEYSTORE_BASE64` (same keystore as MyHome) as yuzic's upload key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)