### PR TITLE
1.3.8: CI auto-ship pipeline + version safety fix

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,25 +2,7 @@ name: Android Build
 
 on:
   workflow_dispatch:
-    inputs:
-      android_version_code:
-        description: "Android versionCode"
-        required: false
-        type: string
-      version_label:
-        description: "Version label"
-        required: false
-        type: string
   workflow_call:
-    inputs:
-      android_version_code:
-        description: "Android versionCode"
-        required: false
-        type: string
-      version_label:
-        description: "Version label"
-        required: false
-        type: string
 
 concurrency: android-build
 
@@ -68,10 +50,13 @@ jobs:
           mkdir -p android/app
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.jks
 
+      - name: Read version from package.json
+        id: version
+        run: echo "label=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
       - name: Run Fastlane Android build
         env:
-          ANDROID_VERSION_CODE: ${{ inputs.android_version_code || github.run_number }}
-          VERSION_LABEL: ${{ inputs.version_label }}
+          VERSION_LABEL: ${{ steps.version.outputs.label }}
           ANDROID_KEYSTORE_PATH: release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,6 +11,16 @@ on:
         description: "Version label"
         required: false
         type: string
+  workflow_call:
+    inputs:
+      android_version_code:
+        description: "Android versionCode"
+        required: false
+        type: string
+      version_label:
+        description: "Version label"
+        required: false
+        type: string
 
 concurrency: android-build
 
@@ -60,8 +70,8 @@ jobs:
 
       - name: Run Fastlane Android build
         env:
-          ANDROID_VERSION_CODE: ${{ github.event.inputs.android_version_code || github.run_number }}
-          VERSION_LABEL: ${{ github.event.inputs.version_label }}
+          ANDROID_VERSION_CODE: ${{ inputs.android_version_code || github.run_number }}
+          VERSION_LABEL: ${{ inputs.version_label }}
           ANDROID_KEYSTORE_PATH: release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -2,25 +2,7 @@ name: iOS Build
 
 on:
   workflow_dispatch:
-    inputs:
-      ios_build_number:
-        description: "iOS build number"
-        required: false
-        type: string
-      version_label:
-        description: "Version label"
-        required: false
-        type: string
   workflow_call:
-    inputs:
-      ios_build_number:
-        description: "iOS build number"
-        required: false
-        type: string
-      version_label:
-        description: "Version label"
-        required: false
-        type: string
 
 concurrency: ios-build
 
@@ -81,10 +63,13 @@ jobs:
         env:
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
 
+      - name: Read version from package.json
+        id: version
+        run: echo "label=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
       - name: Run Fastlane iOS build
         env:
-          IOS_BUILD_NUMBER: ${{ inputs.ios_build_number }}
-          VERSION_LABEL: ${{ inputs.version_label }}
+          VERSION_LABEL: ${{ steps.version.outputs.label }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_API_KEY_BASE64: ${{ secrets.APPSTORE_API_KEY_BASE64 }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -11,6 +11,16 @@ on:
         description: "Version label"
         required: false
         type: string
+  workflow_call:
+    inputs:
+      ios_build_number:
+        description: "iOS build number"
+        required: false
+        type: string
+      version_label:
+        description: "Version label"
+        required: false
+        type: string
 
 concurrency: ios-build
 
@@ -73,8 +83,8 @@ jobs:
 
       - name: Run Fastlane iOS build
         env:
-          IOS_BUILD_NUMBER: ${{ github.event.inputs.ios_build_number }}
-          VERSION_LABEL: ${{ github.event.inputs.version_label }}
+          IOS_BUILD_NUMBER: ${{ inputs.ios_build_number }}
+          VERSION_LABEL: ${{ inputs.version_label }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           APPSTORE_API_KEY_BASE64: ${{ secrets.APPSTORE_API_KEY_BASE64 }}

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}
-      version: ${{ steps.check.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +29,6 @@ jobs:
           else
             OLD_VERSION=""
           fi
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -43,8 +41,6 @@ jobs:
     if: needs.detect-version-bump.outputs.changed == 'true'
     uses: ./.github/workflows/android-build.yml
     secrets: inherit
-    with:
-      version_label: ${{ needs.detect-version-bump.outputs.version }}
 
   build-ios:
     name: Ship iOS build
@@ -52,5 +48,3 @@ jobs:
     if: needs.detect-version-bump.outputs.changed == 'true'
     uses: ./.github/workflows/ios-build.yml
     secrets: inherit
-    with:
-      version_label: ${{ needs.detect-version-bump.outputs.version }}

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -1,0 +1,56 @@
+name: Release on Version Bump
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - package.json
+
+concurrency: release-on-version-bump
+
+jobs:
+  detect-version-bump:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Compare package.json version to previous commit
+        id: check
+        run: |
+          NEW_VERSION=$(jq -r .version package.json)
+          if git cat-file -e HEAD^:package.json 2>/dev/null; then
+            OLD_VERSION=$(git show HEAD^:package.json | jq -r .version)
+          else
+            OLD_VERSION=""
+          fi
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-android:
+    name: Ship Android build
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.changed == 'true'
+    uses: ./.github/workflows/android-build.yml
+    secrets: inherit
+    with:
+      version_label: ${{ needs.detect-version-bump.outputs.version }}
+
+  build-ios:
+    name: Ship iOS build
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.changed == 'true'
+    uses: ./.github/workflows/ios-build.yml
+    secrets: inherit
+    with:
+      version_label: ${{ needs.detect-version-bump.outputs.version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent instructions for yuzic
+
+## Branch model
+
+- `dev` is the long-running integration branch. Push work here (directly or via PR) — do not delete it after merging.
+- `master` is the stable/release branch. Promote work from `dev` to `master` via a PR (e.g. #137), not by pushing directly.
+- Both branches have GitHub branch protection requiring the `Lint, Typecheck & Test` check (from `.github/workflows/pr-checks.yml`) to pass before a PR can merge. Repo admins can bypass this for direct pushes — it does not block `git push` outright.
+
+## CI
+
+- `.github/workflows/pr-checks.yml`: lint (`npm run lint`), typecheck (`npx tsc --noEmit`), and tests (`npx jest --ci`) on every push/PR to `master` and `dev`. Keep this green — it's what branch protection gates on.
+- `.github/workflows/android-build.yml` / `ios-build.yml`: build and ship to Play's alpha track / App Store Connect (TestFlight only — `submit_for_review: false`, never public review). Runnable manually (`workflow_dispatch`) or called by the release workflow (`workflow_call`). No manual version inputs — see below.
+- `.github/workflows/release-on-version-bump.yml`: on push to `master`, if `package.json`'s `version` field changed from the previous commit, automatically calls both build workflows.
+
+## Version numbers — do not reintroduce manual overrides
+
+Android versionCode and iOS build number are derived automatically and must **never** be manually typed in per-run — a human-entered duplicate is exactly what gets a build rejected by Play/App Store Connect, since both require every new version code/build number to be strictly greater than everything published before.
+
+The mechanism (see `fastlane/Fastfile`):
+- `VERSION_LABEL` (e.g. `1.3.7`) is read directly from `package.json` at build time — single source of truth, never passed as a workflow input.
+- `ANDROID_VERSION_CODE` / `IOS_BUILD_NUMBER` derive from `GITHUB_RUN_NUMBER` (GitHub's per-workflow-file counter — starts at 1, increments forever, never resets or repeats) **plus a fixed offset** (`ANDROID_LAST_PUBLISHED_VERSION_CODE` / `IOS_LAST_PUBLISHED_BUILD_NUMBER` constants at the top of `Fastfile`). The offset exists because CI's run counter started from 0 while the stores already had real published versions ahead of it.
+
+**Last known published versions** (recorded here so this doesn't silently break again):
+- Android: version 1.3.7, versionCode **109**
+- iOS: version 1.3.7, build **1**
+
+If you ever need to raise these offset constants (e.g. because a manual/local Fastlane run published a version CI didn't know about), only ever increase them, and update this table to match. Do not remove the offset mechanism or reintroduce `workflow_dispatch` inputs for version numbers — that reopens the exact collision risk it was built to close.
+
+## Native/player notes
+
+- Audio playback goes through `@rntp/player` (the npm-scoped continuation of `react-native-track-player`, now under a commercial license as of v5 — see `node_modules/@rntp/player/package.json`). Keep it reasonably current; v5.0.0 → v5.6.0 fixed real bugs (notably `file://` local-playback support added in 5.2.0).
+- `src/contexts/PlayingContext.tsx` is the central playback state/controls context — most player-related work touches this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md) for repo-wide instructions (branch model, CI, and — critically — the version-numbering rules for the release workflows). Read it before touching anything under `.github/workflows/` or `fastlane/`.

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Yuzic",
     "slug": "yuzic",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "myapp",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,8 +3,24 @@ Dotenv.load
 
 default_platform(:android)
 
+# Last versionCode/build number actually published to Play/App Store Connect
+# before CI started auto-deriving these from GITHUB_RUN_NUMBER. Play and
+# App Store Connect both reject uploads whose version code/build number
+# isn't strictly greater than everything published before, so CI adds these
+# as a fixed offset on top of the ever-increasing run number. Never lower
+# these constants — only raise them if you learn the true published value is
+# higher than what's recorded here.
+ANDROID_LAST_PUBLISHED_VERSION_CODE = 109
+IOS_LAST_PUBLISHED_BUILD_NUMBER = 1
+
 def resolved_android_version_code
-  raw = ENV["ANDROID_VERSION_CODE"] || ENV["GITHUB_RUN_NUMBER"] || Time.now.to_i.to_s
+  if ENV["ANDROID_VERSION_CODE"]
+    raw = ENV["ANDROID_VERSION_CODE"]
+  elsif ENV["GITHUB_RUN_NUMBER"]
+    raw = (ENV["GITHUB_RUN_NUMBER"].to_i + ANDROID_LAST_PUBLISHED_VERSION_CODE).to_s
+  else
+    raw = Time.now.to_i.to_s
+  end
   code = raw.to_i
 
   if code <= 0 || raw.to_s !~ /\A\d+\z/
@@ -28,7 +44,13 @@ def resolved_version_label
 end
 
 def resolved_ios_build_number
-  raw = ENV["IOS_BUILD_NUMBER"] || ENV["GITHUB_RUN_NUMBER"] || Time.now.to_i.to_s
+  if ENV["IOS_BUILD_NUMBER"]
+    raw = ENV["IOS_BUILD_NUMBER"]
+  elsif ENV["GITHUB_RUN_NUMBER"]
+    raw = (ENV["GITHUB_RUN_NUMBER"].to_i + IOS_LAST_PUBLISHED_BUILD_NUMBER).to_s
+  else
+    raw = Time.now.to_i.to_s
+  end
   value = raw.to_i
 
   if value <= 0 || raw.to_s !~ /\A\d+\z/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yuzic",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuzic",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "dependencies": {
         "@backpackapp-io/react-native-toast": "^0.13.0",
         "@gorhom/bottom-sheet": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuzic",
   "main": "expo-router/entry",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## Summary
- Add `release-on-version-bump.yml`: auto-ships Android (Play alpha track) and iOS (TestFlight via App Store Connect, `submit_for_review: false`) whenever `package.json`'s version changes on `master`. `android-build.yml`/`ios-build.yml` are now reusable (`workflow_call`) and no longer accept manual version overrides — those were the exact path a duplicate/rejected version number could sneak in through.
- Fix a real version-code collision risk: the run-number-derived Android versionCode would have started at 20, below the already-published 109. Added a fixed offset in `fastlane/Fastfile` so derived version codes/build numbers always land above the last known published values (Android 109, iOS build 1), recorded in the new `AGENTS.md`.
- Add `AGENTS.md` (repo/CI/branch/versioning conventions for coding agents) and `CLAUDE.md` (pointer to it, auto-loaded by Claude Code).
- Bump version to 1.3.8 — this merge is also the first real trigger of the new pipeline.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes with 0 problems
- [x] `npx jest --ci` passes (9 suites, 31 tests)
- [x] `ruby -c fastlane/Fastfile` — syntax OK
- [x] Manually verified the version-code offset arithmetic against actual current run numbers (Android run 19→20+109=129, iOS run 30→31+1=32), both safely above the last published versions
- [ ] Not verified: an actual live TestFlight/Play upload (first real run happens on merge)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RNSAmCMBZhKvdA6WSQuQFh)_