### PR TITLE
Add PR template and automated tag/draft-release creation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+<!-- What does this PR change, and why? -->
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Testing
+<!-- How did you verify this? Commands run, devices/servers tested against. -->
+
+## Related issues
+<!-- Fixes #123 -->

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -5,6 +5,16 @@ on:
     branches: [master]
     paths:
       - package.json
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag/release (e.g. 1.3.8). For backfilling a release that shipped before this workflow existed - does not trigger app builds."
+        required: false
+        type: string
+      target:
+        description: "Commit SHA or ref to tag (defaults to whatever commit this run is on)"
+        required: false
+        type: string
 
 concurrency: release-on-version-bump
 
@@ -14,37 +24,74 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+      target: ${{ steps.check.outputs.target }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: Compare package.json version to previous commit
+      - name: Resolve version, change status, and target
         id: check
         run: |
-          NEW_VERSION=$(jq -r .version package.json)
-          if git cat-file -e HEAD^:package.json 2>/dev/null; then
-            OLD_VERSION=$(git show HEAD^:package.json | jq -r .version)
-          else
-            OLD_VERSION=""
-          fi
-          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+          if [ -n "${{ inputs.version }}" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            NEW_VERSION=$(jq -r .version package.json)
+            if git cat-file -e HEAD^:package.json 2>/dev/null; then
+              OLD_VERSION=$(git show HEAD^:package.json | jq -r .version)
+            else
+              OLD_VERSION=""
+            fi
+            if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           fi
+          echo "target=${{ inputs.target || github.sha }}" >> "$GITHUB_OUTPUT"
+
+  draft-release:
+    name: Create draft release
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create tag and draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.detect-version-bump.outputs.version }}
+          TARGET: ${{ needs.detect-version-bump.outputs.target }}
+        run: |
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists, skipping."
+            exit 0
+          fi
+          NOTES=$(printf '### **Version %s**\n\n#### What'"'"'s New\n- \n\n#### Bug Fixes\n- \n' "$VERSION")
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "$NOTES" \
+            --target "$TARGET" \
+            --draft
 
   build-android:
     name: Ship Android build
     needs: detect-version-bump
-    if: needs.detect-version-bump.outputs.changed == 'true'
+    if: needs.detect-version-bump.outputs.changed == 'true' && github.event_name == 'push'
     uses: ./.github/workflows/android-build.yml
     secrets: inherit
 
   build-ios:
     name: Ship iOS build
     needs: detect-version-bump
-    if: needs.detect-version-bump.outputs.changed == 'true'
+    if: needs.detect-version-bump.outputs.changed == 'true' && github.event_name == 'push'
     uses: ./.github/workflows/ios-build.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `.github/pull_request_template.md`
- `release-on-version-bump.yml` now also creates a git tag and draft GitHub Release on version bump, scaffolded with the same headers every release since 1.1.14 has used by hand (Version / What's New / Bug Fixes) — left empty for a human to write
- Adds a `workflow_dispatch` path (version + target inputs) for backfilling a release after the fact without re-triggering app store builds — needed since 1.3.8 and 1.3.9 shipped before this existed

## Type of change
- [x] CI / tooling
- [x] Documentation

## Testing
- Dispatched manually against `dev` to validate the tag/release-creation logic (see workflow runs)

## Related issues
N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01RNSAmCMBZhKvdA6WSQuQFh)_