### PR TITLE
Fix playback error-retry infinite loop; remove dead handleSearch

### DIFF
--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -336,7 +336,11 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   }, [bumpQueue, clearPlaybackState]);
   removeFailedCurrentTrackRef.current = removeFailedCurrentTrack;
 
-  const lastRecoveryAtRef = useRef(0);
+  // Id of the track we've already attempted one URL-refresh retry for. Keyed by
+  // song id rather than a time window — a wall-clock gate breaks when a failure
+  // (e.g. an unreachable server) takes longer than the window to surface, which
+  // makes every retry look like a "first" attempt and loops forever.
+  const lastRecoveryAttemptedIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     const subscription = TrackPlayer.addEventListener(Event.PlaybackError, event => {
@@ -359,10 +363,10 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
         return;
       }
 
-      // First error: refresh every URL in the queue (catches stale Navidrome tokens
-      // after JS context restarts) then retry from the current index.
-      if (now - lastRecoveryAtRef.current > 3000) {
-        lastRecoveryAtRef.current = now;
+      // First failure for this specific track: refresh every URL in the queue
+      // (catches stale Navidrome tokens after JS context restarts) then retry.
+      if (song?.id && lastRecoveryAttemptedIdRef.current !== song.id) {
+        lastRecoveryAttemptedIdRef.current = song.id;
         const freshQueue = queueRef.current.map(s => resolvePlayableSongRef.current(s));
         queueRef.current = freshQueue;
         currentSongRef.current = freshQueue[currentIndexRef.current] ?? song;
@@ -371,7 +375,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
         return;
       }
 
-      // Second error within 3s — URL refresh didn't help, genuine failure.
+      // This track failed again after a retry — URL refresh didn't help, genuine failure.
       if (now - lastPlaybackErrorAtRef.current > 1500) {
         lastPlaybackErrorAtRef.current = now;
         toast.error(t('common.playbackError'));
@@ -397,6 +401,10 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   useEffect(() => {
     const mediaId = activeMediaItem?.mediaId;
     if (!mediaId) return;
+
+    // A media item is only reported active once it's actually playing, so this
+    // track is no longer in the "just retried once" state from the error handler.
+    lastRecoveryAttemptedIdRef.current = null;
 
     const prev = currentSongRef.current;
     if (prev && prev.id !== mediaId) {

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -43,7 +43,6 @@ interface SearchContextType {
   searchExternal: (query: string) => Promise<SearchResult[]>;
   clearSearch: () => void;
   isLoading: boolean;
-  handleSearch: (query: string) => Promise<void>;
   handleSearchWithFilters: (query: string, filters: SearchFilters) => Promise<void>;
 }
 
@@ -346,48 +345,6 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     setIsLoading(false);
   }, []);
 
-  const handleSearch = useCallback(async (query: string) => {
-    const requestId = ++searchRequestIdRef.current;
-
-    if (!query.trim()) {
-      setSearchResults([]);
-      setIsLoading(false);
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      const lowerQuery = query.toLowerCase();
-      const results: SearchResult[] = [];
-
-      if (searchScope.includes('client')) {
-        results.push(...await searchLibrary(query));
-      }
-      if (requestId !== searchRequestIdRef.current) return;
-
-      if (searchScope.includes('server')) {
-        try {
-          results.push(...await searchServer(query));
-        } catch {}
-      }
-      if (requestId !== searchRequestIdRef.current) return;
-
-      if (searchScope.includes('external')) {
-        try {
-          results.push(...await searchExternal(query));
-        } catch {}
-      }
-      if (requestId !== searchRequestIdRef.current) return;
-
-      setSearchResults(dedupeAndSort(results, lowerQuery));
-    } finally {
-      if (requestId === searchRequestIdRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, [searchExternal, searchLibrary, searchScope, searchServer]);
-
   const handleSearchWithFilters = useCallback(async (query: string, filters: SearchFilters) => {
     const requestId = ++searchRequestIdRef.current;
     if (!query.trim()) {
@@ -428,7 +385,6 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     searchExternal,
     clearSearch,
     isLoading,
-    handleSearch,
     handleSearchWithFilters,
   }), [
     searchResults,
@@ -436,7 +392,6 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     searchExternal,
     clearSearch,
     isLoading,
-    handleSearch,
     handleSearchWithFilters,
   ]);
 


### PR DESCRIPTION
## Summary
- **Bug fix:** `PlayingContext`'s `PlaybackError` handler decided whether to retry-once-then-give-up using a 3-second wall-clock window (`now - lastRecoveryAtRef.current > 3000`). That window resets on every retry, so if a failure consistently takes longer than 3s to resurface (e.g. an unreachable server timing out, rather than a fast stale-token rejection), every retry looks like a fresh "first" attempt — the track loops forever with no error toast and no fallback to the next track. Likely the cause of "song hangs and doesn't continue on queue" style reports (see #70). Replaced the time window with a marker keyed by song id: retry once per track regardless of how long the failure takes to surface, escalate to toast + skip on the second failure for that same track, and clear the marker once a track is confirmed actively playing so it gets a fresh chance later.
- **Cleanup:** Removed `handleSearch` from `SearchContext`. It had no callers — the search screen only uses `handleSearchWithFilters` — and its external/Deezer branch (`searchScope.includes('external')`) could never fire anyway since `SearchScope` only has `'client'`/`'server'` values.

## Type of change
- [x] Bug fix
- [x] Refactor / cleanup

## Testing
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npx jest --ci` (18 suites / 68 tests passing)

## Related issues
May help #70 (song hangs on connection loss and never continues the queue), though I haven't been able to reproduce/confirm against a real unreachable-server scenario on a device.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_