### PR TITLE
Add manually-triggered EAS preview build workflow

### DIFF
--- a/.github/workflows/eas-preview-build.yml
+++ b/.github/workflows/eas-preview-build.yml
@@ -1,0 +1,69 @@
+name: EAS Preview Build
+
+# Ad-hoc internal-distribution build for trying out a change on a real device —
+# not a store release. Uses eas.json's "preview" profile, so it never touches
+# Play/App Store Connect, versionCode/build number, or any release track.
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to build for"
+        required: true
+        type: choice
+        options:
+          - android
+          - ios
+          - all
+        default: android
+
+concurrency: eas-preview-build
+
+jobs:
+  build:
+    name: EAS Preview Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Run EAS preview build
+        run: |
+          eas build \
+            --profile preview \
+            --platform ${{ inputs.platform }} \
+            --non-interactive \
+            --json > eas-build-output.json
+          cat eas-build-output.json
+
+      - name: Summarize build links
+        if: always()
+        run: |
+          echo "### EAS Preview Build" >> "$GITHUB_STEP_SUMMARY"
+          if [ -s eas-build-output.json ]; then
+            jq -r '.[] | "- **\(.platform // "build")**: \(.artifacts.buildUrl // .buildDetailsPageUrl // "see EAS dashboard")"' \
+              eas-build-output.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+            echo '<details><summary>Raw eas build output</summary>' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat eas-build-output.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo '</details>' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No build output captured — check the job log above." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/eas-preview-build.yml`: a `workflow_dispatch`-triggered build using `eas.json`'s existing `preview` profile (internal distribution).
- Lets you get an installable build to try a change on a real device without touching Play/App Store Connect, the versionCode/build-number derivation, or any release track — unlike `android-build.yml`/`ios-build.yml`, which always publish for real.
- Waits for the EAS build to finish and writes the download link to the job's step summary.

## Type of change
- [x] CI / tooling

## Testing
- Validated the workflow YAML parses correctly.
- Not run end-to-end: this requires an `EXPO_TOKEN` repo secret (an Expo access token) that doesn't exist yet — needs to be added in repo settings before the workflow can actually execute.

## Related issues
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_