### PR TITLE
Minimize fullscreen player on Android back button

### DIFF
--- a/src/screens/playing/playingBar/PlayingBarBase.tsx
+++ b/src/screens/playing/playingBar/PlayingBarBase.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, memo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { ActivityIndicator, BackHandler, StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { Music, Play, Pause } from 'lucide-react-native';
 import { BlurView } from 'expo-blur';
@@ -209,6 +209,7 @@ export default function PlayingBarBase({ variant }: Props) {
   const bottomSheetRef = useSheetRef();
   const playlistSheetRef = useSheetRef();
   const castSheetRef = useSheetRef();
+  const [isPlayerSheetOpen, setIsPlayerSheetOpen] = useState(false);
 
   const primaryAction = usePlayingBarAction(actionMode, {
     presentAddToPlaylist: () => {
@@ -216,6 +217,18 @@ export default function PlayingBarBase({ variant }: Props) {
     },
     presentCast: () => castSheetRef.current?.present(),
   });
+
+  // Android's hardware back button isn't intercepted by the bottom sheet on its
+  // own (it renders in a Portal, not a native Modal) — without this it falls
+  // through to whatever screen is underneath instead of minimizing the player.
+  useEffect(() => {
+    if (!isPlayerSheetOpen) return;
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      bottomSheetRef.current?.close();
+      return true;
+    });
+    return () => subscription.remove();
+  }, [isPlayerSheetOpen, bottomSheetRef]);
 
   const [currentGradient, setCurrentGradient] = useState<[string, string]>(['#000', '#000']);
   const [nextGradient, setNextGradient] = useState<[string, string]>(['#000', '#000']);
@@ -391,6 +404,7 @@ export default function PlayingBarBase({ variant }: Props) {
         snapPoints={['100%']}
         enableDynamicSizing={false}
         enablePanDownToClose
+        onChange={(index) => setIsPlayerSheetOpen(index >= 0)}
         backgroundStyle={{ backgroundColor: 'transparent' }}
         backgroundComponent={props => (
           <PlayingBackground


### PR DESCRIPTION
## Summary
- The fullscreen player (`PlayingBarBase.tsx`) is a `@gorhom/bottom-sheet` `BottomSheetModal`, which renders in a Portal rather than React Native's native `Modal` — so it never got Android's automatic hardware-back interception. Pressing the system back button while the player was expanded fell through to whatever screen was underneath instead of minimizing the sheet.
- Tracks the sheet's open state via its existing `onChange` callback (same pattern already used elsewhere in the codebase, e.g. `AlbumOptions.tsx`) and, while open, handles `hardwareBackPress` to close the sheet and swallow the event.
- No-op on iOS — `BackHandler` only fires on Android.

## Type of change
- [x] Bug fix

## Testing
- `npx tsc --noEmit`, `npm run lint`, `npx jest --ci` (18 suites / 68 tests) all pass.
- Not device-tested — no Android device/emulator available in this environment; logic was verified by tracing the existing `onChange`-based open-state pattern already used by other sheets in this codebase.

## Related issues
Fixes #143


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_