### PR TITLE
Fix search bar color and wrong-tab highlighting on pushed detail screens

### DIFF
--- a/src/app/(home)/_layout.tsx
+++ b/src/app/(home)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, useRouter, usePathname } from 'expo-router';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AppState, View, TouchableOpacity, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector, useDispatch } from 'react-redux';
@@ -90,9 +90,24 @@ export default function HomeLayout() {
         }
     }, [activeServerId, dispatch, sync])
 
-    const isSearch = pathname === '/search'
-    const isLibrary = pathname === '/library'
-    const isHome = !isLibrary && !isSearch
+    // Tracks which tab is "active" for the tab bar's highlight — driven by the
+    // last real tab route visited, not the literal current pathname. Detail
+    // screens (albumView, artistView, settings, etc.) are pushed as Stack
+    // siblings of the tabs rather than nested inside each tab's own stack, so
+    // pathname alone can't tell us which tab a pushed screen belongs to —
+    // without this, opening any of them would fall through to a "not
+    // library, not search" default and incorrectly highlight Home.
+    const [activeTab, setActiveTab] = useState<'home' | 'search' | 'library'>('home')
+
+    useEffect(() => {
+        if (pathname === '/') setActiveTab('home')
+        else if (pathname === '/search') setActiveTab('search')
+        else if (pathname === '/library') setActiveTab('library')
+    }, [pathname])
+
+    const isSearch = activeTab === 'search'
+    const isLibrary = activeTab === 'library'
+    const isHome = activeTab === 'home'
     const activeColor = themeColor
     const inactiveColor = colors.subtext
     const activeIndicatorBg = isDarkMode ? `${themeColor}28` : `${themeColor}18`

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -36,6 +36,13 @@ import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelecto
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
 
+// Fixed regardless of theme (Spotify-style white search field) — the box
+// doesn't follow dark/light mode, so its contents can't use the theme's
+// text colors either, which assume light text on a dark background.
+const SEARCH_BAR_BACKGROUND = '#fff';
+const SEARCH_BAR_FOREGROUND = '#111';
+const SEARCH_BAR_MUTED_FOREGROUND = '#8E8E93';
+
 const Search = () => {
   const searchInputRef = useRef<TextInput>(null);
   const songOptionsRef = useSheetRef();
@@ -223,15 +230,15 @@ const Search = () => {
   return (
     <SafeAreaView testID="search-screen" edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.headerRow}>
-        <View style={[styles.searchContainer, { backgroundColor: colors.muted }]}>
-          <SearchIcon size={20} color={colors.subtext} style={styles.searchIcon} />
+        <View style={[styles.searchContainer, { backgroundColor: SEARCH_BAR_BACKGROUND }]}>
+          <SearchIcon size={20} color={SEARCH_BAR_MUTED_FOREGROUND} style={styles.searchIcon} />
           <TextInput
             accessibilityLabel="Search input"
             testID="search-input"
             ref={searchInputRef}
-            style={[styles.searchInput, { color: colors.secondary }]}
+            style={[styles.searchInput, { color: SEARCH_BAR_FOREGROUND }]}
             placeholder={t('search.placeholder')}
-            placeholderTextColor={colors.placeholder}
+            placeholderTextColor={SEARCH_BAR_MUTED_FOREGROUND}
             value={query}
             onChangeText={onSearchChange}
             returnKeyType="search"
@@ -242,7 +249,7 @@ const Search = () => {
               style={styles.clearButton}
               onPress={() => { setQuery(''); clearSearch(); setHasSearched(false); }}
             >
-              <X size={20} color={colors.secondary} />
+              <X size={20} color={SEARCH_BAR_FOREGROUND} />
             </TouchableOpacity>
           )}
         </View>
@@ -325,8 +332,8 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: 14,
-    paddingHorizontal: 14,
+    borderRadius: 8,
+    paddingHorizontal: 12,
   },
   searchIcon: {
     marginRight: 8,
@@ -334,7 +341,7 @@ const styles = StyleSheet.create({
   searchInput: {
     flex: 1,
     fontSize: 16,
-    paddingVertical: 14,
+    paddingVertical: 8,
   },
   clearButton: {
     padding: 4,

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Text,
 } from 'react-native';
-import { Ellipsis, X } from 'lucide-react-native';
+import { Ellipsis, Search as SearchIcon, X } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -224,6 +224,7 @@ const Search = () => {
     <SafeAreaView testID="search-screen" edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.headerRow}>
         <View style={[styles.searchContainer, { backgroundColor: colors.muted }]}>
+          <SearchIcon size={20} color={colors.subtext} style={styles.searchIcon} />
           <TextInput
             accessibilityLabel="Search input"
             testID="search-input"
@@ -324,13 +325,16 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: 8,
-    paddingHorizontal: 12,
+    borderRadius: 14,
+    paddingHorizontal: 14,
+  },
+  searchIcon: {
+    marginRight: 8,
   },
   searchInput: {
     flex: 1,
     fontSize: 16,
-    paddingVertical: 8,
+    paddingVertical: 14,
   },
   clearButton: {
     padding: 4,


### PR DESCRIPTION
## Summary

Two unrelated small fixes that ended up on the same branch:

**1. Search bar background color** (`screens/search/index.tsx`)
- The search bar used the theme's `colors.muted` grey (`#333` dark / `#eee` light) for its fill, which barely stood out from the screen background, especially in light mode.
- Adds a leading magnifying-glass icon inside the bar.
- Makes the box's background a fixed white regardless of theme (Spotify-style), rather than following dark/light mode. Box size/radius are unchanged — this was about the fill color, not the shape.
- Since the box no longer follows the theme, its contents (input text, placeholder, clear-button icon, search icon) now use fixed dark colors instead of `colors.secondary`/`colors.subtext`/`colors.placeholder`, which assume light text on a dark background and would have had no contrast against a white fill in dark mode.

**2. Tab bar highlighting the wrong tab on pushed detail screens** (`app/(home)/_layout.tsx`)
- `isHome` was a catch-all (`!isLibrary && !isSearch`), so any pushed Stack screen that isn't exactly `/library` or `/search` — `albumView`, `artistView`, `playlistView`, `genreView`, `settings`, etc. — fell through to "Home" regardless of which tab it was opened from. Opening an album from the Library tab, for example, switched the tab bar's highlight to Home.
- These detail screens are pushed as Stack siblings of the tabs rather than nested inside each tab's own stack, so pathname alone can't say which tab a pushed screen belongs to. Now tracks the last real tab route visited instead, and leaves it unchanged while on any other route, so the tab you pushed from stays highlighted underneath the detail screen.

## Type of change
- [x] Bug fix
- [x] Refactor / cleanup

## Testing
- `npx tsc --noEmit`, `npm run lint`, `npx jest --ci` (18 suites / 68 tests) pass.
- No device/simulator available in this environment — neither change has been visually/interactively verified on an actual screen.

## Related issues
None.
