### PR TITLE
Revert search bar styling and tab-highlight fix

### DIFF
--- a/src/app/(home)/_layout.tsx
+++ b/src/app/(home)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, useRouter, usePathname } from 'expo-router';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { AppState, View, TouchableOpacity, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector, useDispatch } from 'react-redux';
@@ -90,24 +90,9 @@ export default function HomeLayout() {
         }
     }, [activeServerId, dispatch, sync])
 
-    // Tracks which tab is "active" for the tab bar's highlight — driven by the
-    // last real tab route visited, not the literal current pathname. Detail
-    // screens (albumView, artistView, settings, etc.) are pushed as Stack
-    // siblings of the tabs rather than nested inside each tab's own stack, so
-    // pathname alone can't tell us which tab a pushed screen belongs to —
-    // without this, opening any of them would fall through to a "not
-    // library, not search" default and incorrectly highlight Home.
-    const [activeTab, setActiveTab] = useState<'home' | 'search' | 'library'>('home')
-
-    useEffect(() => {
-        if (pathname === '/') setActiveTab('home')
-        else if (pathname === '/search') setActiveTab('search')
-        else if (pathname === '/library') setActiveTab('library')
-    }, [pathname])
-
-    const isSearch = activeTab === 'search'
-    const isLibrary = activeTab === 'library'
-    const isHome = activeTab === 'home'
+    const isSearch = pathname === '/search'
+    const isLibrary = pathname === '/library'
+    const isHome = !isLibrary && !isSearch
     const activeColor = themeColor
     const inactiveColor = colors.subtext
     const activeIndicatorBg = isDarkMode ? `${themeColor}28` : `${themeColor}18`

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Text,
 } from 'react-native';
-import { Ellipsis, Search as SearchIcon, X } from 'lucide-react-native';
+import { Ellipsis, X } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -35,13 +35,6 @@ import { useSelector } from 'react-redux';
 import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelectors';
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
-
-// Fixed regardless of theme (Spotify-style white search field) — the box
-// doesn't follow dark/light mode, so its contents can't use the theme's
-// text colors either, which assume light text on a dark background.
-const SEARCH_BAR_BACKGROUND = '#fff';
-const SEARCH_BAR_FOREGROUND = '#111';
-const SEARCH_BAR_MUTED_FOREGROUND = '#8E8E93';
 
 const Search = () => {
   const searchInputRef = useRef<TextInput>(null);
@@ -230,15 +223,14 @@ const Search = () => {
   return (
     <SafeAreaView testID="search-screen" edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.headerRow}>
-        <View style={[styles.searchContainer, { backgroundColor: SEARCH_BAR_BACKGROUND }]}>
-          <SearchIcon size={20} color={SEARCH_BAR_MUTED_FOREGROUND} style={styles.searchIcon} />
+        <View style={[styles.searchContainer, { backgroundColor: colors.muted }]}>
           <TextInput
             accessibilityLabel="Search input"
             testID="search-input"
             ref={searchInputRef}
-            style={[styles.searchInput, { color: SEARCH_BAR_FOREGROUND }]}
+            style={[styles.searchInput, { color: colors.secondary }]}
             placeholder={t('search.placeholder')}
-            placeholderTextColor={SEARCH_BAR_MUTED_FOREGROUND}
+            placeholderTextColor={colors.placeholder}
             value={query}
             onChangeText={onSearchChange}
             returnKeyType="search"
@@ -249,7 +241,7 @@ const Search = () => {
               style={styles.clearButton}
               onPress={() => { setQuery(''); clearSearch(); setHasSearched(false); }}
             >
-              <X size={20} color={SEARCH_BAR_FOREGROUND} />
+              <X size={20} color={colors.secondary} />
             </TouchableOpacity>
           )}
         </View>
@@ -334,9 +326,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderRadius: 8,
     paddingHorizontal: 12,
-  },
-  searchIcon: {
-    marginRight: 8,
   },
   searchInput: {
     flex: 1,


### PR DESCRIPTION
## Summary
Reverts both changes merged in #151:
- The search bar's fixed white background + leading icon (`screens/search/index.tsx`), back to the theme-following `colors.muted` grey with no leading icon.
- The tab bar's last-active-tab tracking for pushed detail screens (`app/(home)/_layout.tsx`), back to the plain pathname-derived `isHome`/`isLibrary`/`isSearch` checks.

Both files are restored to their exact state as of #150 (verified via `git checkout` against that merge commit, not hand-reconstructed).

## Type of change
- [x] Refactor / cleanup

## Testing
- `npx tsc --noEmit`, `npm run lint`, `npx jest --ci` (18 suites / 68 tests) pass.

## Related issues
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_