### PR TITLE
Add the shared header to the Search tab

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -461,6 +461,7 @@
     }
   },
   "search": {
+    "title": "Search",
     "placeholder": "Search for music, artists, or playlists...",
     "noResults": "No results found"
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -426,6 +426,7 @@
     }
   },
   "search": {
+    "title": "Recherche",
     "placeholder": "Rechercher de la musique, des artistes ou des listes de lecture...",
     "noResults": "Aucun résultat trouvé",
     "chips": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -426,6 +426,7 @@
     }
   },
   "search": {
+    "title": "検索",
     "placeholder": "音楽、アーティスト、プレイリストを検索...",
     "noResults": "結果が見つかりません",
     "chips": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -426,6 +426,7 @@
     }
   },
   "search": {
+    "title": "搜索",
     "placeholder": "搜索音乐、歌手或播放列表...",
     "noResults": "未找到结果",
     "chips": {

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import {
   View,
   TextInput,
@@ -33,13 +33,17 @@ import { usePlayableSongResolver } from '@/hooks/songs';
 import { useDeezerSearchEnabled } from '@/features/home/hooks/useDeezerEnabled';
 import { useSelector } from 'react-redux';
 import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelectors';
+import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
+import HomeHeader from '@/screens/library/components/Header';
+import AccountBottomSheet from '@/screens/library/components/AccountBottomSheet';
 
 const Search = () => {
   const searchInputRef = useRef<TextInput>(null);
   const songOptionsRef = useSheetRef();
   const playlistListRef = useSheetRef();
+  const accountSheetRef = useSheetRef();
   const navigation = useNavigation<any>();
   const { navigateToAlbum, navigateToArtist } = useMatchedNavigation();
   const { t } = useTranslation();
@@ -48,6 +52,17 @@ const Search = () => {
   const { resolvePlayableSong } = usePlayableSongResolver();
   const deezerSearchEnabled = useDeezerSearchEnabled();
   const showSourceHeaders = useSelector(selectShowSourceHeaders);
+  const username = useSelector(selectActiveServer)?.username;
+
+  const [isAccountSheetOpen, setIsAccountSheetOpen] = useState(false);
+  const toggleAccountSheet = useCallback(() => {
+    if (isAccountSheetOpen) {
+      accountSheetRef.current?.dismiss();
+    } else {
+      setIsAccountSheetOpen(true);
+      accountSheetRef.current?.present();
+    }
+  }, [accountSheetRef, isAccountSheetOpen]);
 
   const [query, setQuery] = useState('');
   const [selectedSong, setSelectedSong] = useState<Song | null>(null);
@@ -222,6 +237,11 @@ const Search = () => {
 
   return (
     <SafeAreaView testID="search-screen" edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
+      <HomeHeader
+        title={t('search.title')}
+        username={username}
+        onAccountPress={toggleAccountSheet}
+      />
       <View style={styles.headerRow}>
         <View style={[styles.searchContainer, { backgroundColor: colors.muted }]}>
           <TextInput
@@ -303,6 +323,10 @@ const Search = () => {
         ref={playlistListRef}
         selectedSong={selectedSong}
         onClose={() => playlistListRef.current?.dismiss()}
+      />
+      <AccountBottomSheet
+        ref={accountSheetRef}
+        onDismiss={() => setIsAccountSheetOpen(false)}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- Search was the only one of the three tabs without the `HomeHeader` title + account-avatar row that Home and Library already show.
- Adds it following the exact same per-tab pattern already established (own `AccountBottomSheet` + toggle callback + `selectActiveServer` username lookup — Home and Library each set this up independently rather than sharing one instance).
- Adds the `search.title` locale key ("Search") across en/fr/ja/zh, since the search screen previously had no title text of its own.

## Type of change
- [x] New feature

## Testing
- `npx tsc --noEmit`, `npm run lint`, `npx jest --ci` (18 suites / 68 tests) pass.
- No device/simulator available in this environment — not visually verified on an actual screen.

## Related issues
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_