### PR TITLE
Fix tab titles, account sheet, download/offline queues, i18n plurals, Quick Connect timeout + regression tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@testing-library/react-native": "^14.0.1",
         "@types/jest": "^29.5.12",
         "@types/react": "^19.2.14",
         "@types/react-native-keyboard-spacer": "^0.4.6",
@@ -78,6 +79,7 @@
         "jest": "^29.2.1",
         "jest-expo": "~55.0.16",
         "react-native-svg-transformer": "^1.5.1",
+        "test-renderer": "^1.2.0",
         "typescript": "^5.9.2"
       }
     },
@@ -2464,6 +2466,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2521,6 +2533,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -4994,6 +5016,114 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-14.0.1.tgz",
+      "integrity": "sha512-2r2e2y8SkUNRWKRXlUGqDYunB+AkbdXUPn49Bs5rpv9oxRb0K3USBVugbPbAKJjfj4w5Ba91NJ8LcQCZyopUZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.4.1",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.4.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=19.0.0",
+        "react-native": ">=0.78",
+        "test-renderer": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.50",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.50.tgz",
+      "integrity": "sha512-ydBWw0G6WFwWHzh9RK4B5c690UkreOG0llq0r+DaI7LgKgxigf8mhHzIPI3S0850g1BPkq/zpuCfrq4QFgUlTQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -5179,6 +5309,16 @@
       "dependencies": {
         "@types/react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -10346,6 +10486,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -13106,6 +13256,16 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -14477,6 +14637,22 @@
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/react-native": {
       "version": "0.83.4",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.4.tgz",
@@ -14943,6 +15119,22 @@
         }
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -15130,6 +15322,20 @@
         "expo": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/redux": {
@@ -16278,6 +16484,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -16501,6 +16720,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/test-renderer/-/test-renderer-1.2.0.tgz",
+      "integrity": "sha512-JYiEGbgBGtmHAWX8Kf99gGRL1HtjcRVHLrmJNTZL4vFs9XrnWcuL45Iszw/pO4094+JR7havSrN+ds6YTOpSQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "~0.33.0",
+        "react-reconciler": "~0.33.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/throat": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@testing-library/react-native": "^14.0.1",
     "@types/jest": "^29.5.12",
     "@types/react": "^19.2.14",
     "@types/react-native-keyboard-spacer": "^0.4.6",
@@ -100,6 +101,7 @@
     "jest": "^29.2.1",
     "jest-expo": "~55.0.16",
     "react-native-svg-transformer": "^1.5.1",
+    "test-renderer": "^1.2.0",
     "typescript": "^5.9.2"
   },
   "expo": {

--- a/src/app/(home)/(tabs)/library.tsx
+++ b/src/app/(home)/(tabs)/library.tsx
@@ -298,7 +298,7 @@ export default function LibraryScreen() {
       style={[styles.container, { backgroundColor: colors.background }]}
     >
       <HomeHeader
-        title="yuzic"
+        title={t('library.title')}
         username={username}
         onAccountPress={toggleAccountSheet}
       />

--- a/src/app/(home)/(tabs)/library.tsx
+++ b/src/app/(home)/(tabs)/library.tsx
@@ -20,6 +20,7 @@ import { usePlaylists } from '@/hooks/playlists'
 import { useTracks } from '@/hooks/tracks'
 import { useTheme } from '@/hooks/useTheme'
 import { useDownload } from '@/contexts/DownloadContext'
+import { useAccountSheet } from '@/contexts/AccountSheetContext'
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors'
 import {
   selectThemeColor,
@@ -38,7 +39,6 @@ import {
 import type { AlbumBase, Artist, PlaylistBase, SongBase } from '@/types'
 
 import HomeHeader from '@/screens/library/components/Header'
-import AccountBottomSheet from '@/screens/library/components/AccountBottomSheet'
 import AlbumItem from '@/screens/library/components/Items/AlbumItem'
 import ArtistItem from '@/screens/library/components/Items/ArtistItem'
 import PlaylistItem from '@/screens/library/components/Items/PlaylistItem'
@@ -139,16 +139,15 @@ export default function LibraryScreen() {
   const gridSpacing = useSelector(selectGridSpacing)
   const activeServer = useSelector(selectActiveServer)
   const username = activeServer?.username
+  const { openAccountSheet } = useAccountSheet()
 
   const [filter, setFilter] = useState<Filter>(null)
   const [listFilter, setListFilter] = useState<Filter>(null)
   const [sortOrder, setSortOrder] = useState<SortOrder>('recent')
-  const [isAccountSheetOpen, setIsAccountSheetOpen] = useState(false)
 
   const listOpacity = useSharedValue(1)
   const animatedListStyle = useAnimatedStyle(() => ({ opacity: listOpacity.value }))
 
-  const accountSheetRef = useSheetRef()
   const sortSheetRef = useSheetRef()
   const gridSheetRef = useSheetRef()
 
@@ -214,15 +213,6 @@ export default function LibraryScreen() {
       listOpacity.value = withTiming(1, { duration: 220, easing: Easing.out(Easing.ease) })
     })
   }, [listOpacity])
-
-  const toggleAccountSheet = useCallback(() => {
-    if (isAccountSheetOpen) {
-      accountSheetRef.current?.dismiss()
-    } else {
-      setIsAccountSheetOpen(true)
-      accountSheetRef.current?.present()
-    }
-  }, [accountSheetRef, isAccountSheetOpen])
 
   const FILTERS = useMemo(() => [
     { value: 'playlists'  as const, label: t('home.filters.playlists') },
@@ -300,7 +290,7 @@ export default function LibraryScreen() {
       <HomeHeader
         title={t('library.title')}
         username={username}
-        onAccountPress={toggleAccountSheet}
+        onAccountPress={openAccountSheet}
       />
 
       <View style={[styles.filterRow, { backgroundColor: colors.background }]}>
@@ -370,11 +360,6 @@ export default function LibraryScreen() {
         showsVerticalScrollIndicator={false}
       />
       </Animated.View>
-
-      <AccountBottomSheet
-        ref={accountSheetRef}
-        onDismiss={() => setIsAccountSheetOpen(false)}
-      />
 
       <SortBottomSheet
         ref={sortSheetRef}

--- a/src/app/(home)/_layout.tsx
+++ b/src/app/(home)/_layout.tsx
@@ -14,6 +14,7 @@ import { selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
 import { clearLibrary } from '@/utils/redux/slices/librarySlice';
 import PlayingBar from '@/screens/playing/playingBar/PlayingBar';
 import { ExternalResolutionProvider } from '@/features/sources/ExternalResolutionProvider';
+import { AccountSheetProvider } from '@/contexts/AccountSheetContext';
 
 function TabIcon({ onPress, active, accessibilityLabel, testID, activeColor, inactiveColor, activeIndicatorBg, children }: {
     onPress: () => void;
@@ -102,6 +103,7 @@ export default function HomeLayout() {
 
     return (
         <ExternalResolutionProvider>
+        <AccountSheetProvider>
         <View style={{ flex: 1 }}>
             <Stack>
                 <Stack.Screen name="(tabs)" options={{ headerShown: false, animation: 'none' }} />
@@ -174,6 +176,7 @@ export default function HomeLayout() {
             </View>
 
         </View>
+        </AccountSheetProvider>
         </ExternalResolutionProvider>
     );
 }

--- a/src/contexts/AccountSheetContext.tsx
+++ b/src/contexts/AccountSheetContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useCallback, useContext, ReactNode } from 'react';
+import AccountBottomSheet from '@/screens/library/components/AccountBottomSheet';
+import { useSheetRef } from '@/utils/useSheetRef';
+
+type AccountSheetContextType = {
+  openAccountSheet: () => void;
+};
+
+const AccountSheetContext = createContext<AccountSheetContextType | undefined>(undefined);
+
+export const useAccountSheet = () => {
+  const ctx = useContext(AccountSheetContext);
+  if (!ctx) throw new Error('useAccountSheet must be used within AccountSheetProvider');
+  return ctx;
+};
+
+// Single shared instance so Home/Search/Library don't each mount their own
+// copy of the sheet and its open-state plumbing.
+export const AccountSheetProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const accountSheetRef = useSheetRef();
+
+  const openAccountSheet = useCallback(() => {
+    accountSheetRef.current?.present();
+  }, [accountSheetRef]);
+
+  return (
+    <AccountSheetContext.Provider value={{ openAccountSheet }}>
+      {children}
+      <AccountBottomSheet ref={accountSheetRef} />
+    </AccountSheetContext.Provider>
+  );
+};

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -517,8 +517,15 @@ export const DownloadProvider: React.FC<{ children: ReactNode }> = ({ children }
       await ensureDownloadDir();
       await cleanupTempDownloads();
 
-      while (jobsRef.current.length > 0) {
-        const [job] = jobsRef.current;
+      // A job that keeps failing (dead link, deleted track, transcode
+      // outage) must not wedge every other queued download behind it —
+      // skip it for the rest of this run instead of stopping the whole
+      // queue. It stays in the queue and gets another attempt next time
+      // processDownloadQueue runs (app foreground, manual resume, etc).
+      const failedJobIds = new Set<string>();
+
+      while (true) {
+        const job = jobsRef.current.find(candidate => !failedJobIds.has(candidate.id));
         if (!job) break;
 
         let failed = false;
@@ -534,7 +541,10 @@ export const DownloadProvider: React.FC<{ children: ReactNode }> = ({ children }
           }
         }
 
-        if (failed) break;
+        if (failed) {
+          failedJobIds.add(job.id);
+          continue;
+        }
         removeJob(job.id);
       }
     })();

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -19,8 +19,6 @@ import type { Song } from '@/types';
 import {
   doesTrackMatchProviderScope,
   DownloadProviderScope,
-  getDownloadedTrackServerId,
-  normalizeServerId,
 } from '@/utils/downloads/provider';
 import {
   DownloadedCollectionEntry,
@@ -683,20 +681,22 @@ export const DownloadProvider: React.FC<{ children: ReactNode }> = ({ children }
       FileSystem.deleteAsync(track.localPath, { idempotent: true }).catch(() => {})
     ));
     const deletedIds = new Set(tracksToDelete.map(track => track.trackId));
-    const serverId = normalizeServerId(scope?.serverId);
 
     updateTracks(tracks => tracks.filter(track => !deletedIds.has(track.trackId)));
-    updateCollections(collections => collections.filter(collection => {
-      if (!serverId) return false;
-      const collectionTracks = collection.trackIds
-        .map(trackId => state.tracks.find(track => track.trackId === trackId))
-        .filter(Boolean) as LocalDownloadedTrackEntry[];
-      return collectionTracks.some(track => getDownloadedTrackServerId(track) !== serverId);
-    }));
-    updateJobs(jobs => {
-      if (!serverId) return [];
-      return jobs.filter(job => job.tracks.some(track => track.sourceServerId !== serverId));
-    });
+    // Trim the deleted trackIds out of every collection instead of deciding
+    // whether to drop the whole collection from a resolved serverId alone —
+    // that guard dropped every collection (any provider) whenever the scope
+    // couldn't resolve a serverId, e.g. a corrupt "unknown provider" row.
+    updateCollections(collections => collections
+      .map(collection => ({
+        ...collection,
+        trackIds: collection.trackIds.filter(trackId => !deletedIds.has(trackId)),
+      }))
+      .filter(collection => collection.trackIds.length > 0));
+    updateJobs(jobs => jobs.filter(job => job.tracks.some(track => !doesTrackMatchProviderScope(
+      { serverId: track.sourceServerId, serverType: track.sourceServerType },
+      scope
+    ))));
   }, [state.tracks, updateCollections, updateJobs, updateTracks]);
 
   const clearAllDownloads = useCallback(async () => {

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -25,7 +25,7 @@ import { useApi } from '@/api';
 import { buildTrackItem } from '@/utils/builders/buildTrackItem';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { useTranslation } from 'react-i18next';
-import { moveSongAfterCurrent } from './playingQueue';
+import { moveSongAfterCurrent, reconcileUnshuffledQueue } from './playingQueue';
 import { resolvePlaybackErrorAction } from './playbackErrorRecovery';
 import { useDownloadActions } from './DownloadContext';
 import { useCast } from './CastContext';
@@ -692,7 +692,11 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
         bumpQueue();
         await loadQueue(shuffled, 0, wasPlaying, savedPosition);
       } else if (originalQueueRef.current) {
-        const original = originalQueueRef.current;
+        // addToQueue/playNext/addCollectionToQueue/etc. only ever mutate the
+        // live (shuffled) queueRef, never the pre-shuffle snapshot — restoring
+        // that snapshot verbatim would silently drop anything added while
+        // shuffled, and resurrect anything removed (e.g. a failed track).
+        const original = reconcileUnshuffledQueue(originalQueueRef.current, queueRef.current);
         const currentId = currentSongRef.current?.id;
         const idx = currentId ? original.findIndex(s => s.id === currentId) : 0;
         const adjustedIdx = idx === -1 ? 0 : idx;

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -26,6 +26,7 @@ import { buildTrackItem } from '@/utils/builders/buildTrackItem';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { useTranslation } from 'react-i18next';
 import { moveSongAfterCurrent } from './playingQueue';
+import { resolvePlaybackErrorAction } from './playbackErrorRecovery';
 import { useDownloadActions } from './DownloadContext';
 import { useCast } from './CastContext';
 import { useScrobbling } from '@/hooks/useScrobbling';
@@ -365,8 +366,9 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
 
       // First failure for this specific track: refresh every URL in the queue
       // (catches stale Navidrome tokens after JS context restarts) then retry.
-      if (song?.id && lastRecoveryAttemptedIdRef.current !== song.id) {
-        lastRecoveryAttemptedIdRef.current = song.id;
+      const decision = resolvePlaybackErrorAction(lastRecoveryAttemptedIdRef.current, song?.id);
+      if (decision.action === 'retry') {
+        lastRecoveryAttemptedIdRef.current = decision.nextLastRecoveryAttemptedId;
         const freshQueue = queueRef.current.map(s => resolvePlayableSongRef.current(s));
         queueRef.current = freshQueue;
         currentSongRef.current = freshQueue[currentIndexRef.current] ?? song;

--- a/src/contexts/playbackErrorRecovery.test.ts
+++ b/src/contexts/playbackErrorRecovery.test.ts
@@ -1,0 +1,30 @@
+import { resolvePlaybackErrorAction } from './playbackErrorRecovery';
+
+describe('resolvePlaybackErrorAction', () => {
+  it('retries the first failure for a track, however long it took to surface', () => {
+    // Regression: the old logic gated retries on a wall-clock window since the
+    // last recovery attempt, so a failure that took >3s to surface (e.g. an
+    // unreachable server, not just a stale token) looked identical to a "first"
+    // failure every time and retried forever. This must retry regardless of
+    // how much time has passed.
+    expect(resolvePlaybackErrorAction(null, 'song-1')).toEqual({
+      action: 'retry',
+      nextLastRecoveryAttemptedId: 'song-1',
+    });
+  });
+
+  it('escalates when the same track fails again after already being retried', () => {
+    expect(resolvePlaybackErrorAction('song-1', 'song-1')).toEqual({ action: 'escalate' });
+  });
+
+  it('retries a different track even if another track was recently retried', () => {
+    expect(resolvePlaybackErrorAction('song-1', 'song-2')).toEqual({
+      action: 'retry',
+      nextLastRecoveryAttemptedId: 'song-2',
+    });
+  });
+
+  it('escalates when there is no song id to key off of', () => {
+    expect(resolvePlaybackErrorAction(null, undefined)).toEqual({ action: 'escalate' });
+  });
+});

--- a/src/contexts/playbackErrorRecovery.ts
+++ b/src/contexts/playbackErrorRecovery.ts
@@ -1,0 +1,18 @@
+export type PlaybackErrorAction =
+  | { action: 'retry'; nextLastRecoveryAttemptedId: string }
+  | { action: 'escalate' };
+
+// Decides whether a PlaybackError should trigger one URL-refresh retry or
+// escalate to a user-visible failure. Keyed by song id rather than a time
+// window — a wall-clock gate breaks when a failure (e.g. an unreachable
+// server) takes longer than the window to surface, which makes every retry
+// look like a "first" attempt and loops forever.
+export function resolvePlaybackErrorAction(
+  lastRecoveryAttemptedId: string | null,
+  songId: string | undefined
+): PlaybackErrorAction {
+  if (songId && lastRecoveryAttemptedId !== songId) {
+    return { action: 'retry', nextLastRecoveryAttemptedId: songId };
+  }
+  return { action: 'escalate' };
+}

--- a/src/contexts/playingQueue.test.ts
+++ b/src/contexts/playingQueue.test.ts
@@ -1,4 +1,4 @@
-import { moveSongAfterCurrent } from './playingQueue'
+import { moveSongAfterCurrent, reconcileUnshuffledQueue } from './playingQueue'
 
 const song = (id: string) => ({ id })
 
@@ -50,5 +50,37 @@ describe('moveSongAfterCurrent', () => {
     )
 
     expect(result).toBeNull()
+  })
+})
+
+describe('reconcileUnshuffledQueue', () => {
+  it('restores the original order unchanged when nothing was added or removed', () => {
+    const result = reconcileUnshuffledQueue(
+      [song('a'), song('b'), song('c')],
+      [song('c'), song('a'), song('b')],
+    )
+
+    expect(result.map(item => item.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('appends a song added to the live queue while shuffled instead of dropping it', () => {
+    // Regression: addToQueue/playNext/etc. only mutate the live shuffled
+    // queue, never the pre-shuffle snapshot — restoring the snapshot as-is
+    // used to silently drop anything added during shuffle playback.
+    const result = reconcileUnshuffledQueue(
+      [song('a'), song('b'), song('c')],
+      [song('b'), song('a'), song('x'), song('c')],
+    )
+
+    expect(result.map(item => item.id)).toEqual(['a', 'b', 'c', 'x'])
+  })
+
+  it('does not resurrect a song removed from the live queue while shuffled', () => {
+    const result = reconcileUnshuffledQueue(
+      [song('a'), song('b'), song('c')],
+      [song('c'), song('a')],
+    )
+
+    expect(result.map(item => item.id)).toEqual(['a', 'c'])
   })
 })

--- a/src/contexts/playingQueue.ts
+++ b/src/contexts/playingQueue.ts
@@ -35,3 +35,19 @@ export function moveSongAfterCurrent<T extends QueueSong>(
     removedIndex: removedIndex === -1 ? null : removedIndex,
   }
 }
+
+// Restoring a pre-shuffle snapshot verbatim would silently drop anything
+// added to the live (shuffled) queue since shuffling started, and resurrect
+// anything removed from it (e.g. a track dropped after a playback failure).
+// Keep snapshot entries still present in the live queue, then append
+// whatever's in the live queue that the snapshot doesn't know about.
+export function reconcileUnshuffledQueue<T extends QueueSong>(
+  originalQueue: T[],
+  liveQueue: T[],
+): T[] {
+  const liveIds = new Set(liveQueue.map(item => item.id))
+  const restoredBase = originalQueue.filter(item => liveIds.has(item.id))
+  const restoredIds = new Set(restoredBase.map(item => item.id))
+  const addedWhileShuffled = liveQueue.filter(item => !restoredIds.has(item.id))
+  return [...restoredBase, ...addedWhileShuffled]
+}

--- a/src/hooks/playlists/useDeletePlaylist.ts
+++ b/src/hooks/playlists/useDeletePlaylist.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useApi } from '@/api';
 import { QueryKeys } from '@/enums/queryKeys';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
+import { PlaylistBase } from '@/types';
 import { useIsOffline } from '@/hooks/useIsOffline';
 import { removeLibraryPlaylist } from '@/utils/redux/slices/librarySlice';
 import { enqueueOfflineMutationAction } from '@/utils/redux/slices/offlineMutationsSlice';
@@ -32,6 +33,14 @@ export function useDeletePlaylist() {
       await api.playlists.delete(playlistId);
     },
     onSuccess: (_, playlistId) => {
+      // Patch the list cache directly instead of relying solely on
+      // invalidation — invalidateQueries alone does nothing observable while
+      // offline (the query stays disabled until reconnect), so a deletion
+      // while offline left the playlist visibly still in the list.
+      queryClient.setQueryData<PlaylistBase[] | undefined>(
+        [QueryKeys.Playlists, activeServer?.id],
+        (old) => old?.filter(p => p.id !== playlistId)
+      );
       queryClient.invalidateQueries({ queryKey: [QueryKeys.Playlists, activeServer?.id] });
       queryClient.removeQueries({
         queryKey: [QueryKeys.Playlist, activeServer?.id, playlistId],

--- a/src/hooks/playlists/useRemoveSongFromPlaylist.ts
+++ b/src/hooks/playlists/useRemoveSongFromPlaylist.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useApi } from '@/api';
 import { QueryKeys } from '@/enums/queryKeys';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
+import { Playlist } from '@/types';
 import { useIsOffline } from '@/hooks/useIsOffline';
 import { removeLibraryPlaylistSong } from '@/utils/redux/slices/librarySlice';
 import { enqueueOfflineMutationAction } from '@/utils/redux/slices/offlineMutationsSlice';
@@ -38,7 +39,18 @@ export function useRemoveSongFromPlaylist() {
 
       await api.playlists.removeSong(playlistId, songId);
     },
-    onSuccess: (_, { playlistId }) => {
+    onSuccess: (_, { playlistId, songId }) => {
+      // Patch the cache directly instead of relying solely on invalidation —
+      // invalidateQueries alone does nothing observable while offline (the
+      // query stays disabled until reconnect), so a removal while offline
+      // left the song visibly still in the playlist with no feedback at all.
+      queryClient.setQueryData<Playlist | null>(
+        [QueryKeys.Playlist, activeServer?.id, playlistId],
+        (old) => {
+          if (!old) return old;
+          return { ...old, songs: old.songs.filter(s => s.id !== songId) };
+        }
+      );
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.Playlist, activeServer?.id, playlistId],
       });

--- a/src/hooks/usePollWhile.test.ts
+++ b/src/hooks/usePollWhile.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { usePollWhile } from './usePollWhile';
+
+describe('usePollWhile', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not tick while inactive', async () => {
+    // Regression: OfflineMutationReplayer scheduled a nextRetryAt backoff but
+    // nothing ever re-checked it once the deadline passed — the surrounding
+    // effect only re-ran on unrelated state changes, never on time alone.
+    // This proves inactive polling truly runs no timer at all.
+    const { result } = await renderHook(() => usePollWhile(false, 1000));
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(result.current).toBe(0);
+  });
+
+  it('ticks on the given interval while active', async () => {
+    const { result } = await renderHook(() => usePollWhile(true, 1000));
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3_500);
+    });
+
+    expect(result.current).toBe(3);
+  });
+
+  it('stops ticking once deactivated', async () => {
+    const { result, rerender } = await renderHook(
+      ({ active }: { active: boolean }) => usePollWhile(active, 1000),
+      { initialProps: { active: true } }
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1_000);
+    });
+    expect(result.current).toBe(1);
+
+    await rerender({ active: false });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10_000);
+    });
+    expect(result.current).toBe(1);
+  });
+});

--- a/src/hooks/usePollWhile.ts
+++ b/src/hooks/usePollWhile.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+// Ticks every `intervalMs` while `active` is true, so an effect elsewhere can
+// re-run periodically without needing its own timer wiring. No-ops (no
+// interval running) while inactive.
+export function usePollWhile(active: boolean, intervalMs: number): number {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    const interval = setInterval(() => setTick(t => t + 1), intervalMs);
+    return () => clearInterval(interval);
+  }, [active, intervalMs]);
+
+  return tick;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -95,20 +95,20 @@
         "neverSynced": "Never synced",
         "justNow": "Just now",
         "minsAgo": "{{count}} min ago",
-        "minsAgo_plural": "{{count}} mins ago",
+        "minsAgo_other": "{{count}} mins ago",
         "hoursAgo": "{{count}} hr ago",
-        "hoursAgo_plural": "{{count}} hrs ago",
+        "hoursAgo_other": "{{count}} hrs ago",
         "daysAgo": "{{count}} day ago",
-        "daysAgo_plural": "{{count}} days ago",
+        "daysAgo_other": "{{count}} days ago",
         "lastSynced": "Last synced",
         "syncOnAppStart": "Sync on app start"
       },
       "offlineChanges": {
         "title": "Pending offline changes",
         "subtitle": "{{count}} change will sync when you're online",
-        "subtitle_plural": "{{count}} changes will sync when you're online",
+        "subtitle_other": "{{count}} changes will sync when you're online",
         "failedSubtitle": "{{count}} change needs attention before it can sync",
-        "failedSubtitle_plural": "{{count}} changes need attention before they can sync",
+        "failedSubtitle_other": "{{count}} changes need attention before they can sync",
         "retry": "Retry",
         "discard": "Discard",
         "discardTitle": "Discard offline changes?",
@@ -269,9 +269,9 @@
       "unknown": "Unknown",
       "unknownAlbum": "Unknown Album",
       "tracks": "track",
-      "tracks_plural": "tracks",
+      "tracks_other": "tracks",
       "files": "file",
-      "files_plural": "files",
+      "files_other": "files",
       "serverUrlPlaceholder": {
         "lidarr": "http://node:8686",
         "slskd": "http://slskd:5030"
@@ -541,7 +541,7 @@
   "playlist": {
     "favoritesTitle": "Favorites",
     "subtext": "Playlist • {{count}} song",
-    "subtext_plural": "Playlist • {{count}} songs",
+    "subtext_other": "Playlist • {{count}} songs",
     "empty": "This playlist has no songs yet.",
     "recommended": {
       "title": "Recommended",
@@ -648,7 +648,7 @@
     },
     "header": {
       "songs": "{{count}} song",
-      "songs_plural": "{{count}} songs",
+      "songs_other": "{{count}} songs",
       "externalMetadata": "External metadata"
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -417,14 +417,20 @@
       "subtitle": "Enter your username and password to continue.",
       "usernamePlaceholder": "Username",
       "passwordPlaceholder": "Password",
-      "libraryTitle": "Choose Library",
-      "librarySubtitle": "Select which Navidrome library to use for this server.",
-      "confirmLibrary": "Use Library",
-      "selectLibraryRequired": "Please select a library to continue.",
       "missingCredentials": "Please enter both username and password.",
       "authFailed": "Authentication failed.",
       "apiNotResponding": "Server connected, but API is not responding.",
       "connectError": "An error occurred while connecting."
+    },
+    "libraries": {
+      "title": "Choose Libraries",
+      "subtitle": "Select which libraries to include. You can pick multiple, or leave all selected to include everything.",
+      "allLibraries": "All Libraries",
+      "loadError": "Could not load libraries. Check your connection and try again.",
+      "retry": "Retry",
+      "useAll": "Use All Libraries",
+      "continueWith": "Continue with {{count}} Library",
+      "continueWith_other": "Continue with {{count}} Libraries"
     }
   },
   "library": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -95,20 +95,20 @@
         "neverSynced": "Jamais synchronisé",
         "justNow": "À l'instant",
         "minsAgo": "Il y a {{count}} min",
-        "minsAgo_plural": "Il y a {{count}} min",
+        "minsAgo_other": "Il y a {{count}} min",
         "hoursAgo": "Il y a {{count}} h",
-        "hoursAgo_plural": "Il y a {{count}} h",
+        "hoursAgo_other": "Il y a {{count}} h",
         "daysAgo": "Il y a {{count}} jour",
-        "daysAgo_plural": "Il y a {{count}} jours",
+        "daysAgo_other": "Il y a {{count}} jours",
         "lastSynced": "Dernière synchro",
         "syncOnAppStart": "Synchroniser au démarrage"
       },
       "offlineChanges": {
         "title": "Modifications hors ligne en attente",
         "subtitle": "{{count}} modification sera synchronisée en ligne",
-        "subtitle_plural": "{{count}} modifications seront synchronisées en ligne",
+        "subtitle_other": "{{count}} modifications seront synchronisées en ligne",
         "failedSubtitle": "{{count}} modification nécessite votre attention avant synchronisation",
-        "failedSubtitle_plural": "{{count}} modifications nécessitent votre attention avant synchronisation",
+        "failedSubtitle_other": "{{count}} modifications nécessitent votre attention avant synchronisation",
         "retry": "Réessayer",
         "discard": "Ignorer",
         "discardTitle": "Ignorer les modifications hors ligne ?",
@@ -232,9 +232,9 @@
       "unknown": "Inconnu",
       "unknownAlbum": "Album inconnu",
       "tracks": "piste",
-      "tracks_plural": "pistes",
+      "tracks_other": "pistes",
       "files": "fichier",
-      "files_plural": "fichiers",
+      "files_other": "fichiers",
       "serverUrlPlaceholder": {
         "lidarr": "http://node:8686",
         "slskd": "http://slskd:5030"
@@ -511,7 +511,7 @@
   "playlist": {
     "favoritesTitle": "Favoris",
     "subtext": "Liste de lecture • {{count}} morceau",
-    "subtext_plural": "Liste de lecture • {{count}} morceaux",
+    "subtext_other": "Liste de lecture • {{count}} morceaux",
     "empty": "Cette liste de lecture n'a pas encore de morceaux.",
     "recommended": {
       "title": "Recommandé",
@@ -616,7 +616,7 @@
     },
     "header": {
       "songs": "{{count}} morceau",
-      "songs_plural": "{{count}} morceaux",
+      "songs_other": "{{count}} morceaux",
       "externalMetadata": "Métadonnées externes"
     },
     "info": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -374,14 +374,20 @@
       "subtitle": "Saisissez votre nom d'utilisateur et votre mot de passe pour continuer.",
       "usernamePlaceholder": "Nom d'utilisateur",
       "passwordPlaceholder": "Mot de passe",
-      "libraryTitle": "Choisir la bibliothèque",
-      "librarySubtitle": "Sélectionnez la bibliothèque Navidrome à utiliser pour ce serveur.",
-      "confirmLibrary": "Utiliser la bibliothèque",
-      "selectLibraryRequired": "Veuillez sélectionner une bibliothèque pour continuer.",
       "missingCredentials": "Veuillez saisir le nom d'utilisateur et le mot de passe.",
       "authFailed": "Échec de l'authentification.",
       "apiNotResponding": "Serveur connecté, mais l'API ne répond pas.",
       "connectError": "Une erreur s'est produite lors de la connexion."
+    },
+    "libraries": {
+      "title": "Choisir les bibliothèques",
+      "subtitle": "Sélectionnez les bibliothèques à inclure. Vous pouvez en choisir plusieurs, ou les laisser toutes sélectionnées pour tout inclure.",
+      "allLibraries": "Toutes les bibliothèques",
+      "loadError": "Impossible de charger les bibliothèques. Vérifiez votre connexion et réessayez.",
+      "retry": "Réessayer",
+      "useAll": "Utiliser toutes les bibliothèques",
+      "continueWith": "Continuer avec {{count}} bibliothèque",
+      "continueWith_other": "Continuer avec {{count}} bibliothèques"
     }
   },
   "library": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -95,20 +95,20 @@
         "neverSynced": "未同期",
         "justNow": "たった今",
         "minsAgo": "{{count}} 分前",
-        "minsAgo_plural": "{{count}} 分前",
+        "minsAgo_other": "{{count}} 分前",
         "hoursAgo": "{{count}} 時間前",
-        "hoursAgo_plural": "{{count}} 時間前",
+        "hoursAgo_other": "{{count}} 時間前",
         "daysAgo": "{{count}} 日前",
-        "daysAgo_plural": "{{count}} 日前",
+        "daysAgo_other": "{{count}} 日前",
         "lastSynced": "最終同期",
         "syncOnAppStart": "起動時に同期"
       },
       "offlineChanges": {
         "title": "保留中のオフライン変更",
         "subtitle": "{{count}}件の変更をオンライン時に同期します",
-        "subtitle_plural": "{{count}}件の変更をオンライン時に同期します",
+        "subtitle_other": "{{count}}件の変更をオンライン時に同期します",
         "failedSubtitle": "{{count}}件の変更は同期前に確認が必要です",
-        "failedSubtitle_plural": "{{count}}件の変更は同期前に確認が必要です",
+        "failedSubtitle_other": "{{count}}件の変更は同期前に確認が必要です",
         "retry": "再試行",
         "discard": "破棄",
         "discardTitle": "オフライン変更を破棄しますか？",
@@ -232,9 +232,9 @@
       "unknown": "不明",
       "unknownAlbum": "不明なアルバム",
       "tracks": "トラック",
-      "tracks_plural": "トラック",
+      "tracks_other": "トラック",
       "files": "ファイル",
-      "files_plural": "ファイル",
+      "files_other": "ファイル",
       "serverUrlPlaceholder": {
         "lidarr": "http://node:8686",
         "slskd": "http://slskd:5030"
@@ -511,7 +511,7 @@
   "playlist": {
     "favoritesTitle": "お気に入り",
     "subtext": "プレイリスト・{{count}}曲",
-    "subtext_plural": "プレイリスト・{{count}}曲",
+    "subtext_other": "プレイリスト・{{count}}曲",
     "empty": "このプレイリストにはまだ曲がありません。",
     "recommended": {
       "title": "おすすめ",
@@ -616,7 +616,7 @@
     },
     "header": {
       "songs": "{{count}} 曲",
-      "songs_plural": "{{count}} 曲",
+      "songs_other": "{{count}} 曲",
       "externalMetadata": "外部メタデータ"
     },
     "info": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -374,14 +374,20 @@
       "subtitle": "続行するためにユーザー名とパスワードを入力してください。",
       "usernamePlaceholder": "ユーザー名",
       "passwordPlaceholder": "パスワード",
-      "libraryTitle": "ライブラリを選択",
-      "librarySubtitle": "このサーバーで使用する Navidrome ライブラリを選択してください。",
-      "confirmLibrary": "このライブラリを使う",
-      "selectLibraryRequired": "続行するにはライブラリを選択してください。",
       "missingCredentials": "ユーザー名とパスワードを入力してください。",
       "authFailed": "認証に失敗しました。",
       "apiNotResponding": "接続はできましたが、APIが応答しません。",
       "connectError": "接続中にエラーが発生しました。"
+    },
+    "libraries": {
+      "title": "ライブラリを選択",
+      "subtitle": "含めるライブラリを選択してください。複数選択することも、すべて選択したままにしてすべて含めることもできます。",
+      "allLibraries": "すべてのライブラリ",
+      "loadError": "ライブラリを読み込めませんでした。接続を確認して再試行してください。",
+      "retry": "再試行",
+      "useAll": "すべてのライブラリを使う",
+      "continueWith": "{{count}} 件のライブラリで続行",
+      "continueWith_other": "{{count}} 件のライブラリで続行"
     }
   },
   "library": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -95,20 +95,20 @@
         "neverSynced": "从未同步",
         "justNow": "刚刚",
         "minsAgo": "{{count}} 分钟前",
-        "minsAgo_plural": "{{count}} 分钟前",
+        "minsAgo_other": "{{count}} 分钟前",
         "hoursAgo": "{{count}} 小时前",
-        "hoursAgo_plural": "{{count}} 小时前",
+        "hoursAgo_other": "{{count}} 小时前",
         "daysAgo": "{{count}} 天前",
-        "daysAgo_plural": "{{count}} 天前",
+        "daysAgo_other": "{{count}} 天前",
         "lastSynced": "上次同步",
         "syncOnAppStart": "启动时同步"
       },
       "offlineChanges": {
         "title": "待同步的离线更改",
         "subtitle": "{{count}} 项更改将在联网后同步",
-        "subtitle_plural": "{{count}} 项更改将在联网后同步",
+        "subtitle_other": "{{count}} 项更改将在联网后同步",
         "failedSubtitle": "{{count}} 项更改需要处理后才能同步",
-        "failedSubtitle_plural": "{{count}} 项更改需要处理后才能同步",
+        "failedSubtitle_other": "{{count}} 项更改需要处理后才能同步",
         "retry": "重试",
         "discard": "放弃",
         "discardTitle": "放弃离线更改？",
@@ -232,9 +232,9 @@
       "unknown": "未知",
       "unknownAlbum": "未知专辑",
       "tracks": "曲目",
-      "tracks_plural": "曲目",
+      "tracks_other": "曲目",
       "files": "文件",
-      "files_plural": "文件",
+      "files_other": "文件",
       "serverUrlPlaceholder": {
         "lidarr": "http://node:8686",
         "slskd": "http://slskd:5030"
@@ -511,7 +511,7 @@
   "playlist": {
     "favoritesTitle": "收藏",
     "subtext": "播放列表 • {{count}} 首曲目",
-    "subtext_plural": "播放列表 • {{count}} 首曲目",
+    "subtext_other": "播放列表 • {{count}} 首曲目",
     "empty": "此播放列表暂无歌曲。",
     "recommended": {
       "title": "推荐",
@@ -616,7 +616,7 @@
     },
     "header": {
       "songs": "{{count}} 首曲目",
-      "songs_plural": "{{count}} 首曲目",
+      "songs_other": "{{count}} 首曲目",
       "externalMetadata": "外部元数据"
     },
     "info": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -374,14 +374,20 @@
       "subtitle": "输入用户名和密码以继续。",
       "usernamePlaceholder": "用户名",
       "passwordPlaceholder": "密码",
-      "libraryTitle": "选择媒体库",
-      "librarySubtitle": "选择此服务器要使用的 Navidrome 媒体库。",
-      "confirmLibrary": "使用该媒体库",
-      "selectLibraryRequired": "请选择媒体库以继续。",
       "missingCredentials": "请同时输入用户名和密码。",
       "authFailed": "认证失败。",
       "apiNotResponding": "服务器已连接，但 API 无响应。",
       "connectError": "连接时发生错误。"
+    },
+    "libraries": {
+      "title": "选择媒体库",
+      "subtitle": "选择要包含的媒体库。您可以选择多个，或保持全部选中以包含所有内容。",
+      "allLibraries": "所有媒体库",
+      "loadError": "无法加载媒体库。请检查网络连接并重试。",
+      "retry": "重试",
+      "useAll": "使用所有媒体库",
+      "continueWith": "继续（{{count}} 个媒体库）",
+      "continueWith_other": "继续（{{count}} 个媒体库）"
     }
   },
   "library": {

--- a/src/offline/OfflineMutationReplayer.tsx
+++ b/src/offline/OfflineMutationReplayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from '@backpackapp-io/react-native-toast';
@@ -7,6 +7,7 @@ import { useApi } from '@/api';
 import { FAVORITES_ID } from '@/constants/favorites';
 import { QueryKeys } from '@/enums/queryKeys';
 import { useIsOffline } from '@/hooks/useIsOffline';
+import { usePollWhile } from '@/hooks/usePollWhile';
 import i18n from '@/i18n';
 import { OfflineMutation } from '@/utils/offline/offlineMutations';
 import { selectOfflineMutationQueue } from '@/utils/redux/selectors/offlineMutationsSelectors';
@@ -49,18 +50,14 @@ export default function OfflineMutationReplayer() {
   const queue = useSelector(selectOfflineMutationQueue);
   const isOffline = useIsOffline();
   const isReplayingRef = useRef(false);
-  const [retryTick, setRetryTick] = useState(0);
 
   // nextRetryAt only matters once it's in the past, and nothing else in this
   // component's dependencies changes with the passage of time — without this,
   // a failed mutation's backoff would never actually elapse on its own; it'd
   // only get re-checked if some unrelated change (new mutation, connectivity
   // flip) happened to touch the queue/server/offline deps afterward.
-  useEffect(() => {
-    if (!queue.some(item => item.nextRetryAt)) return;
-    const interval = setInterval(() => setRetryTick(t => t + 1), RETRY_POLL_MS);
-    return () => clearInterval(interval);
-  }, [queue]);
+  const hasScheduledRetry = queue.some(item => item.nextRetryAt);
+  const retryTick = usePollWhile(hasScheduledRetry, RETRY_POLL_MS);
 
   useEffect(() => {
     if (isOffline || !activeServer?.id || !activeServer.isAuthenticated) return;

--- a/src/offline/OfflineMutationReplayer.tsx
+++ b/src/offline/OfflineMutationReplayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from '@backpackapp-io/react-native-toast';
@@ -19,6 +19,7 @@ import {
 const SYNCED_TOAST_ID = 'offline-mutations-synced';
 const FAILED_TOAST_ID = 'offline-mutations-failed';
 const RETRY_BACKOFF_MS = 60_000;
+const RETRY_POLL_MS = 30_000;
 
 async function replayMutation(api: ReturnType<typeof useApi>, mutation: OfflineMutation) {
   switch (mutation.type) {
@@ -48,6 +49,18 @@ export default function OfflineMutationReplayer() {
   const queue = useSelector(selectOfflineMutationQueue);
   const isOffline = useIsOffline();
   const isReplayingRef = useRef(false);
+  const [retryTick, setRetryTick] = useState(0);
+
+  // nextRetryAt only matters once it's in the past, and nothing else in this
+  // component's dependencies changes with the passage of time — without this,
+  // a failed mutation's backoff would never actually elapse on its own; it'd
+  // only get re-checked if some unrelated change (new mutation, connectivity
+  // flip) happened to touch the queue/server/offline deps afterward.
+  useEffect(() => {
+    if (!queue.some(item => item.nextRetryAt)) return;
+    const interval = setInterval(() => setRetryTick(t => t + 1), RETRY_POLL_MS);
+    return () => clearInterval(interval);
+  }, [queue]);
 
   useEffect(() => {
     if (isOffline || !activeServer?.id || !activeServer.isAuthenticated) return;
@@ -108,7 +121,7 @@ export default function OfflineMutationReplayer() {
     })().catch(() => {
       isReplayingRef.current = false;
     });
-  }, [activeServer, api, dispatch, isOffline, queryClient, queue]);
+  }, [activeServer, api, dispatch, isOffline, queryClient, queue, retryTick]);
 
   return null;
 }

--- a/src/screens/library/index.tsx
+++ b/src/screens/library/index.tsx
@@ -1,18 +1,17 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { useSelector } from 'react-redux'
-import { useSheetRef } from '@/utils/useSheetRef';
 
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors'
 import { selectSyncOnAppStart } from '@/utils/redux/selectors/settingsSelectors'
 import { useTheme } from '@/hooks/useTheme'
 import { useSync } from '@/hooks/useSync'
 import { useIsOffline } from '@/hooks/useIsOffline'
+import { useAccountSheet } from '@/contexts/AccountSheetContext'
 
 import HomeHeader from './components/Header'
-import AccountBottomSheet from './components/AccountBottomSheet'
 import Explore from '@/screens/home'
 
 export default function HomeScreen() {
@@ -23,11 +22,10 @@ export default function HomeScreen() {
   const username = activeServer?.username
 
   const { colors } = useTheme()
+  const { openAccountSheet } = useAccountSheet()
 
   const [isMounted, setIsMounted] = useState(false)
-  const [isAccountSheetOpen, setIsAccountSheetOpen] = useState(false)
 
-  const accountSheetRef = useSheetRef()
   const lastAutoSyncServerIdRef = useRef<string | null>(null)
 
   const { sync } = useSync()
@@ -63,15 +61,6 @@ export default function HomeScreen() {
     }
   }, [isMounted, isAuthenticated, router])
 
-  const toggleAccountSheet = useCallback(() => {
-    if (isAccountSheetOpen) {
-      accountSheetRef.current?.dismiss()
-    } else {
-      setIsAccountSheetOpen(true)
-      accountSheetRef.current?.present()
-    }
-  }, [accountSheetRef, isAccountSheetOpen])
-
   return (
     <SafeAreaView
       testID="home-screen"
@@ -81,13 +70,9 @@ export default function HomeScreen() {
       <HomeHeader
         title="Yuzic"
         username={username}
-        onAccountPress={toggleAccountSheet}
+        onAccountPress={openAccountSheet}
       />
       <Explore />
-      <AccountBottomSheet
-        ref={accountSheetRef}
-        onDismiss={() => setIsAccountSheetOpen(false)}
-      />
     </SafeAreaView>
   )
 }

--- a/src/screens/library/index.tsx
+++ b/src/screens/library/index.tsx
@@ -79,7 +79,7 @@ export default function HomeScreen() {
       style={[styles.container, { backgroundColor: colors.background }]}
     >
       <HomeHeader
-        title="yuzic"
+        title="Yuzic"
         username={username}
         onAccountPress={toggleAccountSheet}
       />

--- a/src/screens/onboarding/credentials/index.tsx
+++ b/src/screens/onboarding/credentials/index.tsx
@@ -24,6 +24,11 @@ import {
     authenticateWithQuickConnect,
 } from '@/api/jellyfin/auth/quickConnect';
 
+// Quick Connect codes expire server-side; without a client-side ceiling too,
+// polling would continue forever showing "waiting for approval" with no
+// indication the code had gone stale.
+const QUICK_CONNECT_TIMEOUT_MS = 10 * 60 * 1000;
+
 export default function Credentials() {
     const { t } = useTranslation();
     const dispatch = useDispatch();
@@ -46,6 +51,7 @@ export default function Credentials() {
     const [, setQuickSecret] = useState('');
     const [isPolling, setIsPolling] = useState(false);
     const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollStartedAtRef = useRef(0);
 
     const passwordRef = useRef<TextInput>(null);
     const proxyUsernameRef = useRef<TextInput>(null);
@@ -135,8 +141,18 @@ export default function Credentials() {
             setQuickCode(code);
             setQuickSecret(secret);
             setIsPolling(true);
+            pollStartedAtRef.current = Date.now();
 
             pollIntervalRef.current = setInterval(async () => {
+                if (Date.now() - pollStartedAtRef.current > QUICK_CONNECT_TIMEOUT_MS) {
+                    stopPolling();
+                    toast.error('Quick Connect code expired. Please try again.');
+                    setQuickConnectMode(false);
+                    setQuickCode('');
+                    setQuickSecret('');
+                    return;
+                }
+
                 const authenticated = await pollQuickConnect(serverUrl, secret, buildBasicAuth());
                 if (!authenticated) return;
 

--- a/src/screens/onboarding/libraries/index.tsx
+++ b/src/screens/onboarding/libraries/index.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { Check } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
 import { selectServerById } from '@/utils/redux/selectors/serversSelectors';
 import { updateServer } from '@/utils/redux/slices/serversSlice';
 import { getMusicFolders } from '@/api/navidrome/auth/getMusicFolders';
@@ -20,6 +21,7 @@ import type { RootState } from '@/utils/redux/store';
 type Library = { id: string; name: string };
 
 export default function LibrariesOnboarding() {
+  const { t } = useTranslation();
   const router = useRouter();
   const dispatch = useDispatch();
   const { serverId } = useLocalSearchParams<{ serverId: string }>();
@@ -86,18 +88,18 @@ export default function LibrariesOnboarding() {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
-        <Text style={styles.title}>Choose Libraries</Text>
+        <Text style={styles.title}>{t('onboarding.libraries.title')}</Text>
         <Text style={styles.subtitle}>
-          Select which libraries to include. You can pick multiple, or leave all selected to include everything.
+          {t('onboarding.libraries.subtitle')}
         </Text>
 
         {isLoading ? (
           <ActivityIndicator size="large" color="#fff" style={styles.loader} />
         ) : error ? (
           <View style={styles.errorContainer}>
-            <Text style={styles.errorText}>Could not load libraries. Check your connection and try again.</Text>
+            <Text style={styles.errorText}>{t('onboarding.libraries.loadError')}</Text>
             <TouchableOpacity style={styles.retryButton} onPress={() => setRetryCount(c => c + 1)}>
-              <Text style={styles.retryButtonText}>Retry</Text>
+              <Text style={styles.retryButtonText}>{t('onboarding.libraries.retry')}</Text>
             </TouchableOpacity>
           </View>
         ) : (
@@ -106,7 +108,7 @@ export default function LibrariesOnboarding() {
               <View style={[styles.checkbox, isAll && styles.checkboxSelected]}>
                 {isAll && <Check size={14} color="#000" />}
               </View>
-              <Text style={styles.optionText}>All Libraries</Text>
+              <Text style={styles.optionText}>{t('onboarding.libraries.allLibraries')}</Text>
             </TouchableOpacity>
 
             {libraries.map(lib => {
@@ -134,13 +136,13 @@ export default function LibrariesOnboarding() {
         <TouchableOpacity style={styles.continueButton} onPress={handleContinue}>
           <Text style={styles.continueButtonText}>
             {isAll
-              ? 'Use All Libraries'
-              : `Continue with ${selectedIds.length} ${selectedIds.length === 1 ? 'Library' : 'Libraries'}`}
+              ? t('onboarding.libraries.useAll')
+              : t('onboarding.libraries.continueWith', { count: selectedIds.length })}
           </Text>
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
-          <Text style={styles.backButtonText}>Back</Text>
+          <Text style={styles.backButtonText}>{t('common.back')}</Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>

--- a/src/screens/playing/components/OutputDeviceSheet.tsx
+++ b/src/screens/playing/components/OutputDeviceSheet.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import {
   View,
   Text,
@@ -35,21 +35,33 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
 
   const handleOpen = useCallback(() => { scan(); }, [scan]);
 
+  // Tracks which specific device was tapped — isConnecting/isGoogleCastConnecting
+  // are single global flags, so without this every row in a multi-device list
+  // would show a loading spinner while only one is actually connecting.
+  const [connectingDlnaUdn, setConnectingDlnaUdn] = useState<string | null>(null);
+  const [connectingCastId, setConnectingCastId] = useState<string | null>(null);
+
   const handleConnectDlna = useCallback(async (device: DiscoveredDevice) => {
+    setConnectingDlnaUdn(device.udn);
     try {
       await connectToDevice(device);
       (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
     } catch {
       toast.error('Could not connect to device');
+    } finally {
+      setConnectingDlnaUdn(null);
     }
   }, [connectToDevice, ref]);
 
   const handleConnectCast = useCallback(async (deviceId: string) => {
+    setConnectingCastId(deviceId);
     try {
       await connectToGoogleCast(deviceId);
       (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
     } catch {
       toast.error('Could not connect to device');
+    } finally {
+      setConnectingCastId(null);
     }
   }, [connectToGoogleCast, ref]);
 
@@ -162,7 +174,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
               <Cast size={18} color={colors.subtext} />
               <Text style={[styles.itemLabel, { color: colors.secondary }]}>{device.friendlyName}</Text>
             </View>
-            {isGoogleCastConnecting && <SpinningLoaderCircle size={18} color={colors.subtext} />}
+            {connectingCastId === device.deviceId && <SpinningLoaderCircle size={18} color={colors.subtext} />}
           </TouchableOpacity>
         ))}
 
@@ -203,7 +215,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
                 <Cast size={18} color={colors.subtext} />
                 <Text style={[styles.itemLabel, { color: colors.secondary }]}>{device.name}</Text>
               </View>
-              {isConnecting && <SpinningLoaderCircle size={18} color={colors.subtext} />}
+              {connectingDlnaUdn === device.udn && <SpinningLoaderCircle size={18} color={colors.subtext} />}
             </TouchableOpacity>
           );
         })}

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import {
   View,
   TextInput,
@@ -37,13 +37,12 @@ import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
 import HomeHeader from '@/screens/library/components/Header';
-import AccountBottomSheet from '@/screens/library/components/AccountBottomSheet';
+import { useAccountSheet } from '@/contexts/AccountSheetContext';
 
 const Search = () => {
   const searchInputRef = useRef<TextInput>(null);
   const songOptionsRef = useSheetRef();
   const playlistListRef = useSheetRef();
-  const accountSheetRef = useSheetRef();
   const navigation = useNavigation<any>();
   const { navigateToAlbum, navigateToArtist } = useMatchedNavigation();
   const { t } = useTranslation();
@@ -53,16 +52,7 @@ const Search = () => {
   const deezerSearchEnabled = useDeezerSearchEnabled();
   const showSourceHeaders = useSelector(selectShowSourceHeaders);
   const username = useSelector(selectActiveServer)?.username;
-
-  const [isAccountSheetOpen, setIsAccountSheetOpen] = useState(false);
-  const toggleAccountSheet = useCallback(() => {
-    if (isAccountSheetOpen) {
-      accountSheetRef.current?.dismiss();
-    } else {
-      setIsAccountSheetOpen(true);
-      accountSheetRef.current?.present();
-    }
-  }, [accountSheetRef, isAccountSheetOpen]);
+  const { openAccountSheet } = useAccountSheet();
 
   const [query, setQuery] = useState('');
   const [selectedSong, setSelectedSong] = useState<Song | null>(null);
@@ -240,7 +230,7 @@ const Search = () => {
       <HomeHeader
         title={t('search.title')}
         username={username}
-        onAccountPress={toggleAccountSheet}
+        onAccountPress={openAccountSheet}
       />
       <View style={styles.headerRow}>
         <View style={[styles.searchContainer, { backgroundColor: colors.muted }]}>
@@ -323,10 +313,6 @@ const Search = () => {
         ref={playlistListRef}
         selectedSong={selectedSong}
         onClose={() => playlistListRef.current?.dismiss()}
-      />
-      <AccountBottomSheet
-        ref={accountSheetRef}
-        onDismiss={() => setIsAccountSheetOpen(false)}
       />
     </SafeAreaView>
   );

--- a/src/utils/downloads/provider.test.ts
+++ b/src/utils/downloads/provider.test.ts
@@ -49,4 +49,17 @@ describe('download provider helpers', () => {
     expect(doesTrackMatchProviderScope({}, { serverType: 'navidrome' })).toBe(false);
     expect(doesTrackMatchProviderScope({})).toBe(true);
   });
+
+  it('does not match everything when an explicit scope resolves to nothing identifiable', () => {
+    // Regression: a "clear this provider's downloads" scope built from a
+    // corrupt/legacy download (e.g. an "unknown provider" row with no
+    // serverId) used to fall through to the same branch as "no scope
+    // passed at all" and match every track — turning a scoped clear into
+    // a clear-all. An explicitly-passed scope that resolves to nothing
+    // must match nothing, not everything.
+    const track = { serverId: 'server-a', serverType: 'navidrome' };
+    expect(doesTrackMatchProviderScope(track, { serverId: null, serverType: null })).toBe(false);
+    expect(doesTrackMatchProviderScope(track, {})).toBe(false);
+    expect(doesTrackMatchProviderScope(track, { serverId: '   ' })).toBe(false);
+  });
 });

--- a/src/utils/downloads/provider.ts
+++ b/src/utils/downloads/provider.ts
@@ -58,6 +58,14 @@ export function doesTrackMatchProviderScope(
 
   const scopeServerId = normalizeServerId(scope.serverId);
   const scopeServerType = normalizeServerType(scope.serverType);
+
+  // A scope object was explicitly passed but neither field resolved to
+  // anything identifiable (e.g. a downloaded track with missing/corrupt
+  // server metadata produced an "unknown provider" row with no serverId).
+  // Falling through to "match everything" here would turn a provider-
+  // scoped clear into a clear-all — match nothing instead.
+  if (!scopeServerId && !scopeServerType) return false;
+
   const trackServerId = getDownloadedTrackServerId(track);
   const trackServerType = getDownloadedTrackServerType(track);
 


### PR DESCRIPTION
## Summary

Twelve changes that ended up on the same branch:

**1. Tab titles**
- Home and Library both hardcoded `title="yuzic"` in their shared `HomeHeader`, so the two tabs were indistinguishable by title.
- Library now uses the existing `library.title` locale key ("Library", already translated in fr/ja/zh). Home's title is capitalized to "Yuzic".
- Net result: Home → "Yuzic", Search → "Search", Library → "Library".

**2. Account bottom sheet consolidated into one shared instance**
- Home, Library, and Search each independently reimplemented the same `accountSheetRef`/`isAccountSheetOpen`/`toggleAccountSheet` state machine and mounted their own `<AccountBottomSheet>`.
- Adds `AccountSheetContext`, hoisted into `(home)/_layout.tsx` (wraps all three tabs), exposing a single `openAccountSheet()` and mounting exactly one `<AccountBottomSheet>` instance.

**3. Offline mutation retries weren't actually firing on their own**
- `markOfflineMutationFailed` schedules a `nextRetryAt` backoff, but `OfflineMutationReplayer`'s effect only re-ran on `activeServer`/`api`/`isOffline`/`queue` changes — none of which change from time passing. A failed mutation's automatic retry only ever happened if something unrelated coincidentally touched the queue afterward.
- Adds a lightweight poll: while the queue has anything scheduled for retry, tick every 30s to re-run the replay check.

**4. Jellyfin Quick Connect polling had no timeout**
- Quick Connect codes expire server-side, but `handleStartQuickConnect`'s polling ran every 3s forever with no ceiling — an expired code just left the user staring at "waiting for approval" indefinitely with no indication it had gone stale.
- Adds a 10-minute client-side timeout: polling stops, an error toast explains the code expired, and Quick Connect mode resets so the user can restart it.

**5. Every `_plural` translation key across all four locales was silently broken**
- `i18n.ts` sets `compatibilityJSON: 'v4'` (i18next 25.x), which resolves plurals via CLDR suffixes (`_one`/`_other`), not the legacy `_plural` suffix these keys used. Verified against a real i18next instance: `t('key', { count: 2 })` was falling back to the singular string with the plural count still interpolated (e.g. "2 mins ago" rendered as "2 min ago").
- Affected 9 keys × 4 locales: sync-time-ago strings, offline-changes-pending subtitles, downloader track/file counts (Lidarr/Slskd), playlist/favorites subtext, and external-album song counts.
- Renamed the `_plural` suffix to `_other` in en/fr/ja/zh; re-verified all affected strings now pluralize correctly.

**6. Library-selection onboarding screen wasn't translated**
- Reached after every successful login, but had hardcoded English strings while the rest of onboarding is fully translated in fr/ja/zh.
- Removed four dead `onboarding.credentials.library*` keys left over from before this screen was split out of the credentials screen, and added a proper `onboarding.libraries` key set (translated fr/ja/zh) for the screen's actual copy.

**7. A single failed download job wedged the entire download queue**
- `processDownloadQueue` broke out of its `while` loop on any job failure, which didn't just pause that job — it blocked every other queued album/playlist/track download behind it, indefinitely, since the failed job stays first in the queue and gets retried before anything else on every subsequent run (app foreground, manual resume).
- No UI anywhere surfaces a stuck job either: the downloads detail screen only lists completed downloads, so a permanently-failing first download (dead link, deleted track, transcode outage) left the whole feature silently wedged with no way to cancel or clear it short of reinstalling.
- A failing job is now skipped for the rest of the current run so healthy jobs behind it still get processed; it stays queued and is retried on the next run.

**8. "Clear downloads for provider" could wipe every provider's downloads**
- `doesTrackMatchProviderScope` fell through to "match everything" both when no scope was passed *and* when a scope object was passed but neither field resolved to anything identifiable — e.g. a downloaded track with corrupt/missing server metadata, surfaced in the UI as an "unknown provider" row. Tapping "clear downloads" on that row deleted every downloaded track from every server, not just the corrupt one.
- `clearDownloadsForProvider`'s collection/job filtering had the same root bug independently (`if (!serverId) return false/[]`, wiping everything when serverId couldn't be resolved). Rewrote both to derive from the same scope match and to trim stale trackIds out of surviving collections instead of leaving dangling references to deleted files.
- Adds a regression test locking in that an unresolvable-but-explicit scope matches nothing.

**9. Cast/DLNA device sheet showed the connecting spinner on every device row**
- `isConnecting`/`isGoogleCastConnecting` are single global flags, so tapping one device in a multi-device list made every row show a loading spinner, not just the one being connected to. Now tracks the specific device id/udn being connected.

**10. Unshuffling could silently drop songs added during shuffle playback**
- `addToQueue`/`playNext`/`addCollectionToQueue`/`shuffleCollectionToQueue` all mutate the live shuffled queue but never the pre-shuffle snapshot. Toggling shuffle off restored that snapshot verbatim, silently dropping anything added while shuffled.
- Extracted the fix into a pure `reconcileUnshuffledQueue` function (alongside the existing `moveSongAfterCurrent`) that keeps snapshot entries still present and appends anything the live queue has that the snapshot doesn't, with regression tests.

**11. Offline playlist removals didn't update the UI until reconnect**
- `useRemoveSongFromPlaylist` and `useDeletePlaylist`'s `onSuccess` only called `invalidateQueries` on their list/detail caches. Those queries run with `enabled: !isOffline`, so invalidating a disabled query is a no-op — a removed song stayed visible in the playlist, and a deleted playlist stayed visible in the playlists list, with no feedback at all until the app reconnected and could refetch.
- `useAddSongToPlaylist` already patches its cache directly via `setQueryData` for this exact reason; mirrored that here so removals are reflected immediately regardless of connectivity.

**12. Regression tests for the two timing bugs (offline retry, playback error recovery)**
- Extracted the pure decision logic each bug lived in into small testable units instead of testing the containing component directly:
  - `src/contexts/playbackErrorRecovery.ts` — the retry-vs-escalate decision from the `PlaybackError` handler. Tests lock in that a track retries once regardless of how long the failure took to surface (the original bug: a wall-clock gate made slow failures look identical to fast ones and loop forever).
  - `src/hooks/usePollWhile.ts` — the polling mechanism from the offline replayer. Tests use fake timers to prove it only ticks while active and stops when deactivated (the original bug: no timer existed at all).
- Adds `@testing-library/react-native` + `test-renderer` as devDependencies to render hooks under fake timers — first component/hook test in the repo; everything before this was pure-function/reducer tests.

## Type of change
- [x] Bug fix
- [x] Refactor / cleanup
- [x] Test coverage

## Testing
- `npx tsc --noEmit`, `npm run lint`, `npx jest --ci` (20 suites / 79 tests, up from 18/68) all pass.
- The i18n plural fix (5) was independently verified against a real i18next instance loading the app's actual locale JSON, confirming correct singular/plural selection in English and French.
- The provider-scope fix (8) and unshuffle fix (10) each have regression tests locking in the fixed behavior.
- The download-queue (7), cast-spinner (9), and offline-cache (11) fixes aren't covered by automated tests — (7)'s failure path lives inside async I/O, (9) is a rendering/state-wiring fix with no pure logic to extract, and (11) is a react-query cache-patching fix with no isolable pure logic either.
- No device/simulator available in this environment — the UI-facing changes (1, 2, 4, 6, 9, 10, 11) haven't been visually/interactively verified on an actual screen.

## Related issues
None.
