### PR TITLE
Fix invisible theme-color selector, dead cast ternary, unbounded Deezer cache, orphaned offline mutations, album resolution option

### DIFF
--- a/src/api/deezer/catalog.ts
+++ b/src/api/deezer/catalog.ts
@@ -58,6 +58,11 @@ const GENRE_CACHE_MS = 30 * DAY_MS;
 const CHART_CACHE_MS = 6 * HOUR_MS;
 const EMPTY_CACHE_MS = HOUR_MS;
 
+// No expiry sweep runs on its own — an expired entry only gets replaced once
+// that exact key is requested again — so without a cap this grows without
+// bound over a long session of browsing/searching external catalog data.
+const CACHE_MAX_ENTRIES = 500;
+
 const memoryCache = new Map<string, { expiresAt: number; value: unknown }>();
 const pendingRequests = new Map<string, Promise<unknown>>();
 
@@ -79,6 +84,9 @@ async function cached<T>(
 
   const request = loader()
     .then(value => {
+      if (!memoryCache.has(key) && memoryCache.size >= CACHE_MAX_ENTRIES) {
+        memoryCache.delete(memoryCache.keys().next().value!);
+      }
       memoryCache.set(key, {
         expiresAt: Date.now() + cacheTtl(value, ttlMs),
         value,

--- a/src/features/sources/ExternalResolutionProvider.tsx
+++ b/src/features/sources/ExternalResolutionProvider.tsx
@@ -37,17 +37,19 @@ export function ExternalResolutionProvider({ children }: { children: React.React
   const [albumPickerItems, setAlbumPickerItems] = useState<PickerItem[]>([]);
   const [artistPickerItems, setArtistPickerItems] = useState<PickerItem[]>([]);
 
-  const resolveAndNavigateToAlbum = useCallback(async (item: ExternalAlbumBase) => {
-    // Library match
-    const normTitle = normalize(item.title);
-    const normArtist = normalize(item.artist);
-    const localMatch = albums.find(a =>
-      (item.id && a.mbid && a.mbid === item.id) ||
-      (normalize(a.title) === normTitle && normalize(a.artist.name) === normArtist)
-    );
-    if (localMatch) {
-      router.push({ pathname: '/(home)/albumView', params: { id: localMatch.id } });
-      return;
+  const resolveAndNavigateToAlbum = useCallback(async (item: ExternalAlbumBase, options?: ResolutionOptions) => {
+    // Library match — skip when the caller explicitly wants an external view
+    if (!options?.skipLocalMatch) {
+      const normTitle = normalize(item.title);
+      const normArtist = normalize(item.artist);
+      const localMatch = albums.find(a =>
+        (item.id && a.mbid && a.mbid === item.id) ||
+        (normalize(a.title) === normTitle && normalize(a.artist.name) === normArtist)
+      );
+      if (localMatch) {
+        router.push({ pathname: '/(home)/albumView', params: { id: localMatch.id } });
+        return;
+      }
     }
 
     if (enabledSources.length === 0) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -377,12 +377,7 @@
       "add": "Add Server",
       "active": "ACTIVE",
       "deleteTitle": "Delete Server",
-      "deleteBody": "Remove {{server}}?",
-      "switchClearTitle": "Switch server and clear downloads?",
-      "switchClearBody": "Switching servers clears local downloads to prevent overlap.",
-      "switchClearConfirm": "Switch & Clear",
-      "switchClearFailedTitle": "Couldn't switch server",
-      "switchClearFailedBody": "Failed to clear downloads before switching servers."
+      "deleteBody": "Remove {{server}}?"
     },
     "connect": {
       "title": "Choose a Server Type",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -338,12 +338,7 @@
       "add": "Ajouter un serveur",
       "active": "ACTIF",
       "deleteTitle": "Supprimer le serveur",
-      "deleteBody": "Supprimer {{server}} ?",
-      "switchClearTitle": "Changer de serveur et effacer les téléchargements ?",
-      "switchClearBody": "Le changement de serveur effacera les téléchargements locaux pour éviter les chevauchements.",
-      "switchClearConfirm": "Changer et effacer",
-      "switchClearFailedTitle": "Impossible de changer de serveur",
-      "switchClearFailedBody": "Échec de l'effacement des téléchargements avant le changement de serveur."
+      "deleteBody": "Supprimer {{server}} ?"
     },
     "connect": {
       "title": "Choisissez un type de serveur",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -338,12 +338,7 @@
       "add": "サーバーを追加",
       "active": "使用中",
       "deleteTitle": "サーバーを削除",
-      "deleteBody": "{{server}} を削除しますか？",
-      "switchClearTitle": "サーバーを切り替えてダウンロードを削除しますか？",
-      "switchClearBody": "重複を防ぐため、切り替え時にローカルのダウンロードを削除します。",
-      "switchClearConfirm": "切り替えて削除",
-      "switchClearFailedTitle": "サーバーを切り替えできませんでした",
-      "switchClearFailedBody": "サーバー切り替え前のダウンロード削除に失敗しました。"
+      "deleteBody": "{{server}} を削除しますか？"
     },
     "connect": {
       "title": "サーバーの種類を選択",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -338,12 +338,7 @@
       "add": "添加服务器",
       "active": "当前使用",
       "deleteTitle": "删除服务器",
-      "deleteBody": "是否删除 {{server}}？",
-      "switchClearTitle": "切换服务器并清空下载内容？",
-      "switchClearBody": "切换服务器会清空本地下载内容，以避免数据冲突。",
-      "switchClearConfirm": "切换并清空",
-      "switchClearFailedTitle": "无法切换服务器",
-      "switchClearFailedBody": "切换服务器前，清空下载内容失败。"
+      "deleteBody": "是否删除 {{server}}？"
     },
     "connect": {
       "title": "选择服务器类型",

--- a/src/screens/onboarding/servers/index.tsx
+++ b/src/screens/onboarding/servers/index.tsx
@@ -17,6 +17,7 @@ import {
     setActiveServer,
     removeServer,
 } from '@/utils/redux/slices/serversSlice';
+import { clearOfflineMutationsForServer } from '@/utils/redux/slices/offlineMutationsSlice';
 import { Ellipsis } from 'lucide-react-native';
 
 import { SERVER_PROVIDERS } from '@/utils/servers/registry';
@@ -57,7 +58,14 @@ export default function Servers() {
                 {
                     text: t('common.delete'),
                     style: 'destructive',
-                    onPress: () => dispatch(removeServer(id)),
+                    onPress: () => {
+                        // Otherwise these become permanently invisible and
+                        // permanently un-retryable: PendingOfflineChanges only
+                        // ever shows entries for the current activeServerId,
+                        // which this server can never be again.
+                        dispatch(clearOfflineMutationsForServer(id));
+                        dispatch(removeServer(id));
+                    },
                 },
             ]
         );

--- a/src/screens/playing/playingBar/actions/usePlayingBarAction.tsx
+++ b/src/screens/playing/playingBar/actions/usePlayingBarAction.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SkipForward, Heart, Dices, Cast, PlusCircle } from 'lucide-react-native';
-import { useCast } from '@/contexts/CastContext';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { useStarSong, useUnstarSong, useStarredSongs } from '@/hooks/starred';
 import { PlayingBarAction } from '@/utils/redux/slices/settingsSlice';
@@ -34,9 +33,6 @@ export function usePlayingBarAction(
   const { songs: starredSongs } = useStarredSongs();
   const star = useStarSong();
   const unstar = useUnstarSong();
-
-  const { activeDevice, isGoogleCastConnected } = useCast();
-  const isCasting = activeDevice != null || isGoogleCastConnected;
 
   const isFavorite =
     !!currentSong &&
@@ -122,7 +118,7 @@ export function usePlayingBarAction(
     case 'cast':
       return {
         id,
-        icon: <Cast size={20} color={isCasting ? '#fff' : '#fff'} />,
+        icon: <Cast size={20} color="#fff" />,
         onPress: options?.presentCast ?? (() => {}),
       };
 

--- a/src/screens/settings/appearance/components/ThemeColor.tsx
+++ b/src/screens/settings/appearance/components/ThemeColor.tsx
@@ -41,7 +41,7 @@ export const ThemeColor: React.FC = () => {
               style={[
                 styles.preset,
                 { backgroundColor: color },
-                themeColor === color && styles.presetSelected,
+                themeColor === color && [styles.presetSelected, { borderColor: colors.secondary }],
               ]}
             />
           ))}
@@ -102,7 +102,6 @@ const styles = StyleSheet.create({
   },
   presetSelected: {
     borderWidth: 2,
-    borderColor: '#fff',
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.3,


### PR DESCRIPTION
## Summary

Five small fixes found during a self-directed review of appearance/theme settings, the playing bar, the Deezer external-catalog integration, server management, and external-source resolution:

1. **Invisible preset-color selection indicator in light mode** — `ThemeColor.tsx`'s selected-preset border was hardcoded white (`presetSelected: { borderColor: '#fff' }`), same as the settings card background in light mode (`colors.card = '#fff'`). There was no visible way to tell which preset swatch was currently active in light mode; it only worked by accident in dark mode where the card is `#222`. Now uses `colors.secondary`, which already contrasts against both card backgrounds.
2. **Dead ternary in the playing bar's cast action** — `usePlayingBarAction.tsx` computed `isCasting` but only used it in `color={isCasting ? '#fff' : '#fff'}` — both branches identical, so it had zero effect (every other action icon in the same switch hardcodes `'#fff'` too, since they all render on the same colored FAB regardless of theme). Removed the dead ternary and its now-unused `useCast()` call.
3. **Unbounded Deezer catalog cache** — `memoryCache` in `src/api/deezer/catalog.ts` had TTL-based expiry but no size cap; an expired entry only gets replaced once that exact key is requested again, so nothing ever shrinks the map. Over a long session of browsing/searching external artists and albums this grows without bound. Capped it at 500 entries with the same oldest-first eviction already used by the gradient cache in `PlayingBarBase.tsx`.
4. **Removing a server left its queued offline mutations orphaned** — deleting a server only touched `serversSlice`. Any offline mutations still queued for that server (unsynced favorites/playlist edits) became permanently invisible *and* permanently un-retryable — `PendingOfflineChanges` only shows entries for the current `activeServerId`, which a removed server can never be again — yet they were never cleared either, just dead weight in the persisted queue forever. Wired up the existing (but previously unused for this purpose) `clearOfflineMutationsForServer` action on removal.
   - Also removed five `onboarding.servers.switchClear*` translation keys, confirmed unused anywhere in the app across all four locales — the copy ("clears local downloads to prevent overlap") suggests a planned confirmation before switching servers that was never wired up to the actual switch action.
5. **`skipLocalMatch` silently had no effect for album resolution** — `resolveAndNavigateToAlbum`'s type signature accepted an `options` param (same `ResolutionOptions` as its artist sibling `resolveAndNavigateToArtist`), but the implementation only declared `item` and ignored any options passed to it. Fully wired through `useMatchedNavigation`'s `navigateToAlbum`, so nothing currently calling it would notice, but the artist path already needs this exact option ("view on Deezer despite a local match") — the album path would have silently done the wrong thing the moment something needed the same.

## Type of change
- [x] Bug fix
- [x] Refactor / cleanup

## Testing
- `npx tsc --noEmit`, `npm run lint`, `npx jest --ci` (20 suites / 79 tests) all pass.
- No device/simulator available in this environment — the light-mode selection-indicator fix hasn't been visually verified on an actual screen.
- The cache cap (3) mirrors an existing untested precedent (`gradientCache`) rather than adding new test infrastructure for a straightforward, low-risk change.

## Related issues
None.
