### PR TITLE
Align library filter row insets with search header

### DIFF
--- a/src/app/(home)/(tabs)/library.tsx
+++ b/src/app/(home)/(tabs)/library.tsx
@@ -380,9 +380,9 @@ const styles = StyleSheet.create({
   pillRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 8,
-    paddingVertical: 12,
-    gap: 4,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 8,
   },
   sortRow: {
     flexDirection: 'row',

--- a/src/screens/library/components/Filters/FilterPill.tsx
+++ b/src/screens/library/components/Filters/FilterPill.tsx
@@ -52,7 +52,6 @@ export function FilterPill<T extends string>({
 
 const styles = StyleSheet.create({
   button: {
-    marginHorizontal: 2,
     paddingVertical: 8,
     paddingHorizontal: 12,
     borderRadius: 8,


### PR DESCRIPTION
## Summary
- The Library tab's filter-pill row used 8px horizontal / 12px vertical padding (plus a stray 2px margin on each pill), while the Search tab's search box used 16px / 14px under the same shared `HomeHeader`.
- This made the extended header row visibly shift position when swiping between the Search and Library tabs.
- Aligned the Library filter row to the same 16px horizontal / 14px vertical insets as Search, and removed the redundant per-pill margin (spacing between pills now comes entirely from the row's `gap`).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Testing
- `npx tsc --noEmit -p tsconfig.json`

## Related issues
N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_