### PR TITLE
Remove Google Cast integration for F-Droid compliance

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,11 +2,7 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/app.json
+++ b/app.json
@@ -30,7 +30,6 @@
         "backgroundColor": "#1c1c1e"
       },
       "permissions": [
-        "android.permission.RECORD_AUDIO",
         "android.permission.MODIFY_AUDIO_SETTINGS"
       ],
       "package": "com.arinora.rawarr"

--- a/app.json
+++ b/app.json
@@ -64,13 +64,6 @@
             "deploymentTarget": "16.0"
           }
         }
-      ],
-      [
-        "react-native-google-cast",
-        {
-          "iosReceiverAppID": "BCF2CA91",
-          "androidReceiverAppID": "BCF2CA91"
-        }
       ]
     ],
     "experiments": {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -304,7 +304,6 @@ PODS:
   - fmt (11.0.2)
   - Gifu (3.5.1)
   - glog (0.3.5)
-  - google-cast-sdk (4.8.4)
   - hermes-engine (0.14.1):
     - hermes-engine/Pre-built (= 0.14.1)
   - hermes-engine/Pre-built (0.14.1)
@@ -386,7 +385,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - PromisesObjC (2.4.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2273,10 +2271,6 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-google-cast (4.9.1):
-    - google-cast-sdk
-    - PromisesObjC
-    - React
   - react-native-netinfo (12.0.1):
     - boost
     - DoubleConversion
@@ -3547,7 +3541,6 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
-  - react-native-google-cast (from `../node_modules/react-native-google-cast`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-network-info (from `../node_modules/react-native-network-info`)
   - react-native-restart (from `../node_modules/react-native-restart`)
@@ -3607,12 +3600,10 @@ SPEC REPOS:
     - CocoaAsyncSocket
     - Delegate
     - Gifu
-    - google-cast-sdk
     - libavif
     - libdav1d
     - libwebp
     - MMKVCore
-    - PromisesObjC
     - SDWebImage
     - SDWebImageAVIFCoder
     - SDWebImageSVGCoder
@@ -3771,8 +3762,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
-  react-native-google-cast:
-    :path: "../node_modules/react-native-google-cast"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-network-info:
@@ -3916,7 +3905,6 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   Gifu: 9f7e52357d41c0739709019eb80a71ad9aab1b6d
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  google-cast-sdk: 32f65af50d164e3c475e79ad123db3cc26fbcd37
   hermes-engine: 1a09f19eb4520ff275c833929c62c77653bac4a5
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3924,7 +3912,6 @@ SPEC CHECKSUMS:
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
   NitroMmkv: c68bb2c29c154913707bc6e66791b2b30dd723c1
   NitroModules: 0ecd2bf2d12a6a2958fe10c5200e8e61cbea0fd0
-  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 9da1d0cf93db23ca8b41e8efe9ae558fd9c0077f
   RCTRequired: 92a63c7041031a131fa5206eb082d53f95729b79
@@ -3962,7 +3949,6 @@ SPEC CHECKSUMS:
   React-logger: 993e4b9793768764e0fdd379ad1d6582f7905463
   React-Mapbuffer: 3a5f700ed673820ab4b1b35ba0cf8476400bc4c5
   React-microtasksnativemodule: 094677e625f12276a8f871844a5ee6a945a90221
-  react-native-google-cast: 7be68a5d0b7eeb95a5924c3ecef8d319ef6c0a44
   react-native-netinfo: a0be8c77f8420a60ddf07eb87be1a36f02a1bd65
   react-native-network-info: 703d4b16ff0ff6f03127728348251bf5f12b823a
   react-native-restart: 0bc732f4461709022a742bb29bcccf6bbc5b4863

--- a/ios/Yuzic.xcodeproj/project.pbxproj
+++ b/ios/Yuzic.xcodeproj/project.pbxproj
@@ -280,7 +280,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoSystemUI/ExpoSystemUI_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/PromisesObjC/FBLPromises_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
@@ -291,14 +290,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/EXDevMenu.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleCastCoreResources.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleCastUIResources.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleCastOptionalUIResources.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/MaterialDialogs.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleSansBold.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleSansMedium.bundle",
-				"${PODS_ROOT}/google-cast-sdk/GoogleCastSDK-ios-4.8.4_static_xcframework/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleSansRegular.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/google-cast-sdk/GoogleCast.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -307,7 +298,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoSystemUI_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FBLPromises_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
@@ -318,14 +308,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevMenu.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleCastCoreResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleCastUIResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleCastOptionalUIResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialDialogs.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSansBold.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSansMedium.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSansRegular.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleCast.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "react-native-draggable-flatlist": "^4.0.3",
         "react-native-exception-handler": "^2.10.10",
         "react-native-gesture-handler": "~2.30.0",
-        "react-native-google-cast": "^4.9.1",
         "react-native-image-colors": "^1.5.2",
         "react-native-mmkv": "4.3.1",
         "react-native-nitro-modules": "0.35.3",
@@ -1470,7 +1469,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@egjs/hammerjs": {
@@ -2390,7 +2389,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2408,7 +2407,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -2483,7 +2482,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
@@ -2497,7 +2496,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -2527,7 +2526,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -2543,7 +2542,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -2588,7 +2587,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2621,7 +2620,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -2636,7 +2635,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -2652,7 +2651,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -6708,7 +6707,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6772,7 +6771,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6838,7 +6837,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -6898,7 +6897,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -6909,7 +6908,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color": {
@@ -7115,7 +7114,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -7391,7 +7390,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -7517,7 +7516,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7533,7 +7532,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7685,7 +7684,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7726,7 +7725,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -8558,7 +8557,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -8587,7 +8586,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -8596,7 +8595,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -9740,7 +9739,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10091,7 +10090,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
@@ -10165,7 +10164,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -10321,7 +10320,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -10418,7 +10417,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -10626,7 +10625,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10785,7 +10784,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10929,7 +10928,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -10946,7 +10945,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10959,7 +10958,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -10974,7 +10973,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -10989,7 +10988,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -11021,7 +11020,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -11048,7 +11047,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -11063,7 +11062,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -11095,7 +11094,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -11129,7 +11128,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -11176,7 +11175,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11197,7 +11196,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -11213,7 +11212,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -11226,7 +11225,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -11358,7 +11357,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -11372,7 +11371,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -11422,7 +11421,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11449,7 +11448,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -11470,7 +11469,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -11484,7 +11483,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -11517,7 +11516,7 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11528,7 +11527,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -11563,7 +11562,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11584,7 +11583,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -11616,7 +11615,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11817,7 +11816,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -11968,7 +11967,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -12342,7 +12341,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/load-bmfont": {
@@ -12540,7 +12539,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -12556,7 +12555,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13091,7 +13090,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13210,7 +13209,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -13376,7 +13375,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -13583,7 +13582,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -13760,7 +13759,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -13881,7 +13880,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -14068,7 +14067,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -14293,7 +14292,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -14574,16 +14573,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-google-cast": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/react-native-google-cast/-/react-native-google-cast-4.9.1.tgz",
-      "integrity": "sha512-/HvIKAaWHtG6aTNCxrNrqA2ftWGkfH0M/2iN+28pdGUXpKmueb33mgL1m8D4zzwEODQMcmpfoCsym1IwDvugBQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-image-colors": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/react-native-image-colors/-/react-native-image-colors-1.5.2.tgz",
@@ -14775,22 +14764,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
-    },
-    "node_modules/react-native-webview": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
-      "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "invariant": "2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.8.3",
@@ -15306,7 +15279,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -15344,7 +15317,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15716,17 +15689,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/shaka-player": {
-      "version": "4.16.26",
-      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.16.26.tgz",
-      "integrity": "sha512-qoSQyqaBsARb+yDc2D9ab7D+4THP0bIAE6/7syCteZY7VtC7RVbHlQ8os8VfU2GAzYWqv9mik1ywDjRuQdvtSg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/shallowequal": {
@@ -16124,7 +16086,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -16262,7 +16224,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16272,7 +16234,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16282,7 +16244,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17104,7 +17066,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -17578,7 +17540,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "jest": "^29.2.1",
         "jest-expo": "~55.0.16",
+        "patch-package": "^8.0.1",
         "react-native-svg-transformer": "^1.5.1",
         "typescript": "^5.9.2"
       }
@@ -5780,6 +5781,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -9467,6 +9475,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -9590,6 +9608,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -11977,6 +12010,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11994,6 +12047,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -12020,6 +12096,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -13927,6 +14013,59 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-dirname": {
@@ -16499,6 +16638,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16858,6 +17007,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:e2e": "maestro test .maestro/smoke.yaml && maestro test .maestro/common-user-flows.yaml",
     "test:e2e:smoke": "maestro test .maestro/smoke.yaml",
     "test:e2e:flows": "maestro test .maestro/common-user-flows.yaml",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "postinstall": "patch-package"
   },
   "overrides": {
     "lucide-react-native": {
@@ -98,6 +99,7 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "jest": "^29.2.1",
     "jest-expo": "~55.0.16",
+    "patch-package": "^8.0.1",
     "react-native-svg-transformer": "^1.5.1",
     "typescript": "^5.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-exception-handler": "^2.10.10",
     "react-native-gesture-handler": "~2.30.0",
-    "react-native-google-cast": "^4.9.1",
     "react-native-image-colors": "^1.5.2",
     "react-native-mmkv": "4.3.1",
     "react-native-nitro-modules": "0.35.3",

--- a/patches/@rntp+player+5.6.0.patch
+++ b/patches/@rntp+player+5.6.0.patch
@@ -1,0 +1,389 @@
+diff --git a/node_modules/@rntp/player/android/build.gradle b/node_modules/@rntp/player/android/build.gradle
+index 32ae595..2208120 100644
+--- a/node_modules/@rntp/player/android/build.gradle
++++ b/node_modules/@rntp/player/android/build.gradle
+@@ -106,8 +106,6 @@ dependencies {
+   implementation "androidx.media3:media3-exoplayer-hls:1.9.2"
+   implementation "androidx.media3:media3-common:1.9.2"
+   implementation "androidx.media3:media3-session:1.9.2"
+-  implementation "androidx.media3:media3-cast:1.9.2"
+-  implementation "androidx.mediarouter:mediarouter:1.7.0"
+ 
+   // Testing
+   testImplementation "junit:junit:4.13.2"
+diff --git a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/CastButtonManager.kt b/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/CastButtonManager.kt
+deleted file mode 100644
+index 726ca01..0000000
+--- a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/CastButtonManager.kt
++++ /dev/null
+@@ -1,77 +0,0 @@
+-/*
+- * Copyright (c) Double Symmetry GmbH
+- * Commercial use requires a license. See https://rntp.dev/pricing
+- */
+-
+-package com.doublesymmetry.trackplayer
+-
+-import android.content.Context
+-import android.graphics.drawable.Drawable
+-import android.util.TypedValue
+-import android.view.ContextThemeWrapper
+-import androidx.core.graphics.drawable.DrawableCompat
+-import androidx.mediarouter.app.MediaRouteButton
+-import androidx.mediarouter.media.MediaRouteSelector
+-import com.doublesymmetry.trackplayer.models.PlayerConfig
+-import com.facebook.react.bridge.ReactApplicationContext
+-import com.facebook.react.uimanager.SimpleViewManager
+-import com.facebook.react.uimanager.ThemedReactContext
+-import com.facebook.react.uimanager.annotations.ReactProp
+-import com.google.android.gms.cast.CastMediaControlIntent
+-import com.google.android.gms.cast.framework.CastButtonFactory
+-
+-class CastButtonManager(private val reactContext: ReactApplicationContext)
+-    : SimpleViewManager<MediaRouteButton>() {
+-
+-  override fun getName() = "TrackPlayerCastButton"
+-
+-  override fun createViewInstance(context: ThemedReactContext): MediaRouteButton {
+-    val appId = PlayerConfig().load(reactContext).castReceiverAppId
+-      ?: CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID
+-    val button = MediaRouteButton(context)
+-    val selector = MediaRouteSelector.Builder()
+-      .addControlCategory(CastMediaControlIntent.categoryForCast(appId))
+-      .build()
+-    button.setRouteSelector(selector)
+-    try {
+-      CastButtonFactory.setUpMediaRouteButton(reactContext, button)
+-    } catch (_: Exception) { }
+-    return button
+-  }
+-
+-  @ReactProp(name = "tintColor", customType = "Color")
+-  fun setTintColor(button: MediaRouteButton, color: Int?) {
+-    if (color == null) return
+-    tintedRemoteIndicator(button.context, color)?.let {
+-      button.setRemoteIndicatorDrawable(it)
+-    }
+-  }
+-
+-  companion object {
+-    /**
+-     * Builds the default Cast icon tinted with [color]. MediaRouteButton has no
+-     * public tint setter, so we resolve its drawable from the MediaRouteButton
+-     * style, tint a mutable copy, and swap it back in. Returns null if the
+-     * drawable can't be resolved.
+-     */
+-    internal fun tintedRemoteIndicator(context: Context, color: Int): Drawable? {
+-      val themed = ContextThemeWrapper(context, androidx.mediarouter.R.style.Theme_MediaRouter)
+-      val styleRes = TypedValue().let { value ->
+-        themed.theme.resolveAttribute(
+-          androidx.mediarouter.R.attr.mediaRouteButtonStyle, value, true
+-        )
+-        value.resourceId
+-      }
+-      if (styleRes == 0) return null
+-      val attrs = themed.obtainStyledAttributes(
+-        styleRes,
+-        androidx.mediarouter.R.styleable.MediaRouteButton
+-      )
+-      val drawable = attrs.getDrawable(
+-        androidx.mediarouter.R.styleable.MediaRouteButton_externalRouteEnabledDrawable
+-      )
+-      attrs.recycle()
+-      return drawable?.mutate()?.also { DrawableCompat.setTint(it, color) }
+-    }
+-  }
+-}
+diff --git a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPackage.kt b/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPackage.kt
+index 4491297..ed26dbe 100644
+--- a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPackage.kt
++++ b/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPackage.kt
+@@ -22,7 +22,7 @@ class TrackPlayerPackage : BaseReactPackage() {
+   }
+ 
+   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+-    return listOf(CastButtonManager(reactContext))
++    return emptyList()
+   }
+ 
+   override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
+diff --git a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPlaybackService.kt b/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPlaybackService.kt
+index 9c0906b..fdbed5c 100644
+--- a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPlaybackService.kt
++++ b/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/TrackPlayerPlaybackService.kt
+@@ -13,8 +13,6 @@ import android.net.Uri
+ import android.os.Bundle
+ import android.os.Build
+ import androidx.annotation.OptIn
+-import androidx.media3.cast.CastPlayer
+-import androidx.media3.cast.RemoteCastPlayer
+ import androidx.media3.common.AudioAttributes
+ import androidx.media3.common.C
+ import androidx.media3.common.ForwardingPlayer
+@@ -49,7 +47,6 @@ import com.google.common.util.concurrent.ListenableFuture
+ import com.doublesymmetry.trackplayer.extensions.emitEvent
+ import com.doublesymmetry.trackplayer.models.BrowseTree
+ import com.doublesymmetry.trackplayer.models.MetadataApplier
+-import com.doublesymmetry.trackplayer.models.TrackPlayerCastMediaItemConverter
+ import com.doublesymmetry.trackplayer.models.MetadataReceivedEvent
+ import com.doublesymmetry.trackplayer.models.StreamMetadataExtractor
+ import com.doublesymmetry.trackplayer.models.PlayerCommand
+@@ -76,7 +73,6 @@ class TrackPlayerPlaybackService: MediaLibraryService(), MediaLibraryService.Med
+   private var playerConfig: PlayerConfig? = null
+   private var simpleCache: SimpleCache? = null
+   private var exoPlayer: ExoPlayer? = null
+-  private var castPlayer: CastPlayer? = null
+   private var activePlayer: Player? = null
+   private var progressSyncTimer: java.util.Timer? = null
+   private var progressSyncExecutor: java.util.concurrent.ExecutorService? = null
+@@ -151,31 +147,7 @@ class TrackPlayerPlaybackService: MediaLibraryService(), MediaLibraryService.Med
+       )
+     }
+ 
+-    // If Cast is enabled, wrap ExoPlayer inside CastPlayer — Media3 automatically
+-    // routes playback to the Chromecast when a session is active, and back to
+-    // ExoPlayer when it ends. No manual player swapping needed.
+-    val activePlayer: Player = config.castReceiverAppId?.let { appId ->
+-      android.util.Log.d("TrackPlayer", "Cast enabled (appId=$appId), building CastPlayer")
+-      try {
+-        val remoteCastPlayer = RemoteCastPlayer.Builder(this)
+-          .setMediaItemConverter(TrackPlayerCastMediaItemConverter())
+-          .build()
+-        CastPlayer.Builder(this)
+-          .setLocalPlayer(built)
+-          .setRemotePlayer(remoteCastPlayer)
+-          .build()
+-          .also {
+-            castPlayer = it
+-            android.util.Log.d(
+-              "TrackPlayer",
+-              "CastPlayer created, isCastSessionAvailable=${it.isCastSessionAvailable()}",
+-            )
+-          }
+-      } catch (e: Exception) {
+-        android.util.Log.e("TrackPlayer", "Cast setup failed — ensure OPTIONS_PROVIDER_CLASS_NAME is set in AndroidManifest.xml", e)
+-        null
+-      }
+-    } ?: built.also { android.util.Log.d("TrackPlayer", "Cast disabled, using ExoPlayer only") }
++    val activePlayer: Player = built.also { android.util.Log.d("TrackPlayer", "Cast disabled, using ExoPlayer only") }
+ 
+     this.activePlayer = activePlayer
+ 
+@@ -361,10 +333,8 @@ class TrackPlayerPlaybackService: MediaLibraryService(), MediaLibraryService.Med
+       mediaSession = null
+     }
+     activePlayer = null
+-    // Release exoPlayer explicitly when Cast is active (CastPlayer may not own it).
+     exoPlayer?.release()
+     exoPlayer = null
+-    castPlayer = null
+     simpleCache?.release()
+     simpleCache = null
+     sharedCache = null
+diff --git a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/models/TrackPlayerCastMediaItemConverter.kt b/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/models/TrackPlayerCastMediaItemConverter.kt
+deleted file mode 100644
+index 2518f2c..0000000
+--- a/node_modules/@rntp/player/android/src/main/java/com/doublesymmetry/trackplayer/models/TrackPlayerCastMediaItemConverter.kt
++++ /dev/null
+@@ -1,201 +0,0 @@
+-/*
+- * Copyright (c) Double Symmetry GmbH
+- * Commercial use requires a license. See https://rntp.dev/pricing
+- */
+-
+-package com.doublesymmetry.trackplayer.models
+-
+-import android.net.Uri
+-import android.os.Bundle
+-import androidx.media3.cast.DefaultMediaItemConverter
+-import androidx.media3.cast.MediaItemConverter
+-import androidx.media3.common.MediaItem
+-import androidx.media3.common.util.UnstableApi
+-import com.google.android.gms.cast.MediaInfo
+-import com.google.android.gms.cast.MediaQueueItem
+-import org.json.JSONArray
+-import org.json.JSONException
+-import org.json.JSONObject
+-
+-/**
+- * Cast [MediaItemConverter] that preserves RNTP fields dropped by [DefaultMediaItemConverter]
+- * (app [MediaItemExtras.METADATA_KEY] payload, artist/album/artwork hints, duration/isLive).
+- */
+-@UnstableApi
+-internal class TrackPlayerCastMediaItemConverter : MediaItemConverter {
+-
+-  private val delegate = DefaultMediaItemConverter()
+-
+-  override fun toMediaQueueItem(mediaItem: MediaItem): MediaQueueItem {
+-    val queueItem = delegate.toMediaQueueItem(mediaItem)
+-    val mediaInfo = queueItem.media ?: return queueItem
+-    val customData = copyCustomData(mediaInfo.customData)
+-    if (!encodeRntpPayload(mediaItem, customData)) {
+-      return queueItem
+-    }
+-    val contentId = checkNotNull(mediaInfo.contentId) { "Cast MediaInfo must have a contentId" }
+-    val builder = MediaInfo.Builder(contentId)
+-      .setStreamType(mediaInfo.streamType)
+-      .setMetadata(mediaInfo.metadata)
+-      .setCustomData(customData)
+-    mediaInfo.contentType?.let { builder.setContentType(it) }
+-    mediaInfo.contentUrl?.let { builder.setContentUrl(it) }
+-    val updatedInfo = builder.build()
+-    return MediaQueueItem.Builder(updatedInfo).build()
+-  }
+-
+-  override fun toMediaItem(mediaQueueItem: MediaQueueItem): MediaItem {
+-    val item = delegate.toMediaItem(mediaQueueItem)
+-    val rntp = mediaQueueItem.media?.customData?.optJSONObject(KEY_RNTP) ?: return item
+-    return decodeRntpPayload(item, rntp)
+-  }
+-
+-  private fun encodeRntpPayload(mediaItem: MediaItem, customData: JSONObject): Boolean {
+-    val meta = mediaItem.mediaMetadata
+-    val payload = JSONObject()
+-    try {
+-      meta.artist?.toString()?.let { payload.put(KEY_ARTIST, it) }
+-      meta.albumTitle?.toString()?.let { payload.put(KEY_ALBUM_TITLE, it) }
+-      meta.artworkUri?.toString()?.let { payload.put(KEY_ARTWORK_URL, it) }
+-      meta.extras?.let { extras ->
+-        if (extras.containsKey(KEY_DURATION)) {
+-          payload.put(KEY_DURATION, extras.getDouble(KEY_DURATION))
+-        }
+-        if (extras.containsKey(KEY_IS_LIVE)) {
+-          payload.put(KEY_IS_LIVE, extras.getBoolean(KEY_IS_LIVE))
+-        }
+-        extras.getBundle(MediaItemExtras.METADATA_KEY)?.let { appExtras ->
+-          payload.put(KEY_EXTRAS, bundleToJson(appExtras))
+-        }
+-      }
+-      if (payload.length() == 0) {
+-        return false
+-      }
+-      customData.put(KEY_RNTP, payload)
+-      return true
+-    } catch (e: JSONException) {
+-      throw RuntimeException(e)
+-    }
+-  }
+-
+-  private fun decodeRntpPayload(item: MediaItem, rntp: JSONObject): MediaItem {
+-    val existing = item.mediaMetadata
+-    val metaBuilder = existing.buildUpon()
+-    if (existing.artist.isNullOrEmpty() && rntp.has(KEY_ARTIST)) {
+-      metaBuilder.setArtist(rntp.getString(KEY_ARTIST))
+-    }
+-    if (existing.albumTitle.isNullOrEmpty() && rntp.has(KEY_ALBUM_TITLE)) {
+-      metaBuilder.setAlbumTitle(rntp.getString(KEY_ALBUM_TITLE))
+-    }
+-    if (existing.artworkUri == null && rntp.has(KEY_ARTWORK_URL)) {
+-      metaBuilder.setArtworkUri(Uri.parse(rntp.getString(KEY_ARTWORK_URL)))
+-    }
+-
+-    val metadataExtras = (item.mediaMetadata.extras?.let { Bundle(it) }) ?: Bundle()
+-    if (rntp.has(KEY_DURATION) && !metadataExtras.containsKey(KEY_DURATION)) {
+-      metadataExtras.putDouble(KEY_DURATION, rntp.getDouble(KEY_DURATION))
+-    }
+-    if (rntp.has(KEY_IS_LIVE) && !metadataExtras.containsKey(KEY_IS_LIVE)) {
+-      metadataExtras.putBoolean(KEY_IS_LIVE, rntp.getBoolean(KEY_IS_LIVE))
+-    }
+-    if (rntp.has(KEY_EXTRAS) && !metadataExtras.containsKey(MediaItemExtras.METADATA_KEY)) {
+-      MediaItemExtras.attachToMetadataExtras(
+-        metadataExtras,
+-        jsonToBundle(rntp.getJSONObject(KEY_EXTRAS)),
+-      )
+-    }
+-
+-    metaBuilder.setExtras(metadataExtras)
+-    return item.buildUpon().setMediaMetadata(metaBuilder.build()).build()
+-  }
+-
+-  private fun copyCustomData(customData: JSONObject?): JSONObject =
+-    if (customData == null) JSONObject() else JSONObject(customData.toString())
+-
+-  private companion object {
+-    const val KEY_RNTP = "rntp"
+-    const val KEY_ARTIST = "artist"
+-    const val KEY_ALBUM_TITLE = "albumTitle"
+-    const val KEY_ARTWORK_URL = "artworkUrl"
+-    const val KEY_DURATION = "duration"
+-    const val KEY_IS_LIVE = "isLive"
+-    const val KEY_EXTRAS = "extras"
+-
+-    fun bundleToJson(bundle: Bundle): JSONObject {
+-      val json = JSONObject()
+-      for (key in bundle.keySet()) {
+-        @Suppress("DEPRECATION")
+-        when (val value = bundle.get(key)) {
+-          null -> Unit
+-          is Boolean -> json.put(key, value)
+-          is Int -> json.put(key, value)
+-          is Long -> json.put(key, value)
+-          is Double -> json.put(key, value)
+-          is Float -> json.put(key, value.toDouble())
+-          is String -> json.put(key, value)
+-          is Bundle -> json.put(key, bundleToJson(value))
+-          is ArrayList<*> -> json.put(key, JSONArray(value.map { listValueToJson(it) }))
+-          else -> json.put(key, value.toString())
+-        }
+-      }
+-      return json
+-    }
+-
+-    private fun listValueToJson(value: Any?): Any = when (value) {
+-      null -> JSONObject.NULL
+-      is Boolean -> value
+-      is Int -> value
+-      is Long -> value
+-      is Double -> value
+-      is Float -> value.toDouble()
+-      is String -> value
+-      is Bundle -> bundleToJson(value)
+-      is ArrayList<*> -> JSONArray(value.map { listValueToJson(it) })
+-      else -> value.toString()
+-    }
+-
+-    fun jsonToBundle(json: JSONObject): Bundle {
+-      val bundle = Bundle()
+-      val keys = json.keys()
+-      while (keys.hasNext()) {
+-        val key = keys.next()
+-        when (val value = json.get(key)) {
+-          JSONObject.NULL -> Unit
+-          is Boolean -> bundle.putBoolean(key, value)
+-          is Int -> bundle.putInt(key, value)
+-          is Long -> bundle.putLong(key, value)
+-          is Double -> bundle.putDouble(key, value)
+-          is String -> bundle.putString(key, value)
+-          is JSONObject -> bundle.putBundle(key, jsonToBundle(value))
+-          is JSONArray -> {
+-            val list = ArrayList<Any?>()
+-            for (i in 0 until value.length()) {
+-              list.add(jsonArrayValueToKotlin(value.get(i)))
+-            }
+-            @Suppress("DEPRECATION")
+-            bundle.putSerializable(key, list)
+-          }
+-        }
+-      }
+-      return bundle
+-    }
+-
+-    private fun jsonArrayValueToKotlin(value: Any?): Any? = when (value) {
+-      JSONObject.NULL, null -> null
+-      is Boolean -> value
+-      is Int -> value
+-      is Long -> value
+-      is Double -> value
+-      is String -> value
+-      is JSONObject -> jsonToBundle(value)
+-      is JSONArray -> {
+-        val list = ArrayList<Any?>()
+-        for (i in 0 until value.length()) {
+-          list.add(jsonArrayValueToKotlin(value.get(i)))
+-        }
+-        list
+-      }
+-      else -> value.toString()
+-    }
+-  }
+-}

--- a/src/contexts/CastContext.tsx
+++ b/src/contexts/CastContext.tsx
@@ -1,12 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import TrackPlayer, { Event } from '@rntp/player';
-import GoogleCast, {
-  useDevices,
-  useCastSession,
-  useRemoteMediaClient,
-  MediaStreamType,
-} from 'react-native-google-cast';
-import type Device from 'react-native-google-cast/lib/typescript/types/Device';
 
 // ─── DLNA ────────────────────────────────────────────────────────────────────
 
@@ -52,13 +45,6 @@ interface CastContextType {
   connectToDevice(device: DlnaDevice): Promise<void>;
   disconnectDevice(): Promise<void>;
 
-  // Google Cast
-  googleCastDevices: Device[];
-  isGoogleCastConnected: boolean;
-  isGoogleCastConnecting: boolean;
-  connectToGoogleCast(deviceId: string): Promise<void>;
-  disconnectGoogleCast(): Promise<void>;
-
   // Shared controls (routed to whichever protocol is active)
   castPause(): Promise<void>;
   castResume(): Promise<void>;
@@ -70,11 +56,6 @@ const CastContext = createContext<CastContextType>({
   isConnecting: false,
   connectToDevice: async () => {},
   disconnectDevice: async () => {},
-  googleCastDevices: [],
-  isGoogleCastConnected: false,
-  isGoogleCastConnecting: false,
-  connectToGoogleCast: async () => {},
-  disconnectGoogleCast: async () => {},
   castPause: async () => {},
   castResume: async () => {},
   castSeek: async () => {},
@@ -89,48 +70,12 @@ export function CastProvider({ children }: { children: React.ReactNode }) {
   const activeDeviceRef = useRef<DlnaDevice | null>(null);
   useEffect(() => { activeDeviceRef.current = activeDevice; }, [activeDevice]);
 
-  // Google Cast hooks (SDK-managed)
-  const castSession = useCastSession();
-  const remoteMediaClient = useRemoteMediaClient();
-  const googleCastDevices = useDevices();
-  const [isGoogleCastConnecting, setIsGoogleCastConnecting] = useState(false);
-  const isGoogleCastConnected = castSession != null;
-
-  // Stable refs for use inside effects
-  const castSessionRef = useRef(castSession);
-  const remoteMediaClientRef = useRef(remoteMediaClient);
-  useEffect(() => { castSessionRef.current = castSession; }, [castSession]);
-  useEffect(() => { remoteMediaClientRef.current = remoteMediaClient; }, [remoteMediaClient]);
-
-  // When track changes, push new URL to whichever renderer is active
+  // When track changes, push new URL to the active renderer.
   useEffect(() => {
     const sub = TrackPlayer.addEventListener(Event.MediaItemTransition, async (event) => {
       if (!event.item?.url) return;
       const url = event.item.url as string;
 
-      // Google Cast
-      if (remoteMediaClientRef.current && castSessionRef.current) {
-        try {
-          await remoteMediaClientRef.current.loadMedia({
-            autoplay: true,
-            mediaInfo: {
-              contentUrl: url,
-              contentType: 'audio/mpeg',
-              streamType: MediaStreamType.BUFFERED,
-              metadata: {
-                type: 'musicTrack',
-                title: event.item.title ?? '',
-                artist: event.item.artist ?? '',
-              },
-            },
-          });
-        } catch (err) {
-          console.warn('[Cast] Google Cast track update failed', err);
-        }
-        return;
-      }
-
-      // DLNA
       const device = activeDeviceRef.current;
       if (!device) return;
       try {
@@ -194,62 +139,15 @@ export function CastProvider({ children }: { children: React.ReactNode }) {
     setActiveDevice(null);
   }, []);
 
-  // ── Google Cast connect/disconnect ──────────────────────────────────────
-
-  const connectToGoogleCast = useCallback(async (deviceId: string) => {
-    setIsGoogleCastConnecting(true);
-    try {
-      const started = await GoogleCast.getSessionManager().startSession(deviceId);
-      if (!started) throw new Error('Failed to start Cast session');
-
-      const currentTrack = TrackPlayer.getActiveMediaItem();
-      if (currentTrack?.url && remoteMediaClientRef.current) {
-        await remoteMediaClientRef.current.loadMedia({
-          autoplay: true,
-          mediaInfo: {
-            contentUrl: currentTrack.url as string,
-            contentType: 'audio/mpeg',
-            streamType: MediaStreamType.BUFFERED,
-            metadata: {
-              type: 'musicTrack',
-              title: currentTrack.title ?? '',
-              artist: currentTrack.artist ?? '',
-            },
-          },
-        });
-      }
-      await TrackPlayer.setVolume(0);
-    } finally {
-      setIsGoogleCastConnecting(false);
-    }
-  }, []);
-
-  const disconnectGoogleCast = useCallback(async () => {
-    try {
-      await GoogleCast.getSessionManager().endCurrentSession(true);
-    } catch (err) {
-      console.warn('[Cast] Google Cast disconnect failed', err);
-    }
-    await TrackPlayer.setVolume(1);
-  }, []);
-
   // ── Shared controls ──────────────────────────────────────────────────────
 
   const castPause = useCallback(async () => {
-    if (remoteMediaClientRef.current && castSessionRef.current) {
-      await remoteMediaClientRef.current.pause();
-      return;
-    }
     const device = activeDeviceRef.current;
     if (!device) return;
     await soapAction(device.avTransportUrl, 'AVTransport', 'Pause', `<InstanceID>0</InstanceID>`);
   }, []);
 
   const castResume = useCallback(async () => {
-    if (remoteMediaClientRef.current && castSessionRef.current) {
-      await remoteMediaClientRef.current.play();
-      return;
-    }
     const device = activeDeviceRef.current;
     if (!device) return;
     await soapAction(device.avTransportUrl, 'AVTransport', 'Play', `
@@ -259,10 +157,6 @@ export function CastProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const castSeek = useCallback(async (position: number) => {
-    if (remoteMediaClientRef.current && castSessionRef.current) {
-      await remoteMediaClientRef.current.seek({ position });
-      return;
-    }
     const device = activeDeviceRef.current;
     if (!device) return;
     const h = Math.floor(position / 3600);
@@ -279,8 +173,6 @@ export function CastProvider({ children }: { children: React.ReactNode }) {
   return (
     <CastContext.Provider value={{
       activeDevice, isConnecting, connectToDevice, disconnectDevice,
-      googleCastDevices, isGoogleCastConnected, isGoogleCastConnecting,
-      connectToGoogleCast, disconnectGoogleCast,
       castPause, castResume, castSeek,
     }}>
       {children}

--- a/src/screens/playing/components/BottomControls.tsx
+++ b/src/screens/playing/components/BottomControls.tsx
@@ -10,8 +10,8 @@ type BottomControlsProps = {
 };
 
 const BottomControls: React.FC<BottomControlsProps> = ({ mode, setMode, onOpenOutputSheet }) => {
-  const { activeDevice, isGoogleCastConnected } = useCast();
-  const isCasting = activeDevice != null || isGoogleCastConnected;
+  const { activeDevice } = useCast();
+  const isCasting = activeDevice != null;
   const iconColor = (active: boolean) => (active ? '#fff' : '#ccc');
 
   return (

--- a/src/screens/playing/components/OutputDeviceSheet.tsx
+++ b/src/screens/playing/components/OutputDeviceSheet.tsx
@@ -29,8 +29,6 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
   const { devices, isScanning, isProbing, scan, probeManual } = useDlnaDiscovery();
   const {
     activeDevice, isConnecting, connectToDevice, disconnectDevice,
-    googleCastDevices, isGoogleCastConnected, isGoogleCastConnecting,
-    connectToGoogleCast, disconnectGoogleCast,
   } = useCast();
 
   const handleOpen = useCallback(() => { scan(); }, [scan]);
@@ -43,15 +41,6 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
       toast.error('Could not connect to device');
     }
   }, [connectToDevice, ref]);
-
-  const handleConnectCast = useCallback(async (deviceId: string) => {
-    try {
-      await connectToGoogleCast(deviceId);
-      (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
-    } catch {
-      toast.error('Could not connect to device');
-    }
-  }, [connectToGoogleCast, ref]);
 
   const handleManualEntry = useCallback(() => {
     Alert.prompt(
@@ -67,8 +56,6 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
       'decimal-pad',
     );
   }, [probeManual]);
-
-  const isBusy = isConnecting || isGoogleCastConnecting;
 
   return (
     <BottomSheetModal
@@ -97,19 +84,18 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
 
         {/* This device — always shown, highlighted when nothing is casting */}
         <TouchableOpacity
-          style={[styles.item, { backgroundColor: !activeDevice && !isGoogleCastConnected ? themeColor + '22' : 'transparent' }]}
+          style={[styles.item, { backgroundColor: !activeDevice ? themeColor + '22' : 'transparent' }]}
           onPress={async () => {
             if (activeDevice) await disconnectDevice();
-            if (isGoogleCastConnected) await disconnectGoogleCast();
             (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
           }}
           activeOpacity={0.7}
         >
           <View style={styles.itemLeft}>
-            <Smartphone size={18} color={!activeDevice && !isGoogleCastConnected ? themeColor : colors.subtext} />
+            <Smartphone size={18} color={!activeDevice ? themeColor : colors.subtext} />
             <Text style={[styles.itemLabel, { color: colors.secondary }]}>This device</Text>
           </View>
-          {!activeDevice && !isGoogleCastConnected && <Check size={18} color={themeColor} />}
+          {!activeDevice && <Check size={18} color={themeColor} />}
         </TouchableOpacity>
 
         {/* AirPlay — iOS only */}
@@ -126,45 +112,6 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
             />
           </View>
         )}
-
-        {/* ── Google Cast ── */}
-        {(googleCastDevices.length > 0 || isGoogleCastConnected) && (
-          <View style={[styles.divider, { backgroundColor: colors.border }]} />
-        )}
-
-        {/* Active Google Cast device */}
-        {isGoogleCastConnected && (
-          <TouchableOpacity
-            style={[styles.item, { backgroundColor: themeColor + '22' }]}
-            onPress={disconnectGoogleCast}
-            activeOpacity={0.7}
-          >
-            <View style={styles.itemLeft}>
-              <Cast size={18} color={themeColor} />
-              <Text style={[styles.itemLabel, { color: colors.secondary, fontWeight: '600' }]}>
-                Casting
-              </Text>
-            </View>
-            <Check size={18} color={themeColor} />
-          </TouchableOpacity>
-        )}
-
-        {/* Discovered Google Cast devices */}
-        {!isGoogleCastConnected && googleCastDevices.map(device => (
-          <TouchableOpacity
-            key={device.deviceId}
-            style={[styles.item, { backgroundColor: 'transparent' }]}
-            onPress={() => handleConnectCast(device.deviceId)}
-            disabled={isBusy}
-            activeOpacity={0.7}
-          >
-            <View style={styles.itemLeft}>
-              <Cast size={18} color={colors.subtext} />
-              <Text style={[styles.itemLabel, { color: colors.secondary }]}>{device.friendlyName}</Text>
-            </View>
-            {isGoogleCastConnecting && <SpinningLoaderCircle size={18} color={colors.subtext} />}
-          </TouchableOpacity>
-        ))}
 
         {/* ── DLNA ── */}
         {(devices.length > 0 || activeDevice) && (
@@ -196,7 +143,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
               key={device.udn}
               style={[styles.item, { backgroundColor: 'transparent' }]}
               onPress={() => handleConnectDlna(device)}
-              disabled={isBusy}
+              disabled={isConnecting}
               activeOpacity={0.7}
             >
               <View style={styles.itemLeft}>
@@ -209,7 +156,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
         })}
 
         {/* Empty state */}
-        {!isScanning && devices.length === 0 && !activeDevice && googleCastDevices.length === 0 && !isGoogleCastConnected && (
+        {!isScanning && devices.length === 0 && !activeDevice && (
           <Text style={[styles.empty, { color: colors.subtext }]}>
             No devices found on your network.
           </Text>

--- a/src/screens/playing/playingBar/actions/usePlayingBarAction.tsx
+++ b/src/screens/playing/playingBar/actions/usePlayingBarAction.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SkipForward, Heart, Dices, Cast, PlusCircle } from 'lucide-react-native';
-import { useCast } from '@/contexts/CastContext';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { useStarSong, useUnstarSong, useStarredSongs } from '@/hooks/starred';
 import { PlayingBarAction } from '@/utils/redux/slices/settingsSlice';
@@ -34,9 +33,6 @@ export function usePlayingBarAction(
   const { songs: starredSongs } = useStarredSongs();
   const star = useStarSong();
   const unstar = useUnstarSong();
-
-  const { activeDevice, isGoogleCastConnected } = useCast();
-  const isCasting = activeDevice != null || isGoogleCastConnected;
 
   const isFavorite =
     !!currentSong &&
@@ -122,7 +118,7 @@ export function usePlayingBarAction(
     case 'cast':
       return {
         id,
-        icon: <Cast size={20} color={isCasting ? '#fff' : '#fff'} />,
+        icon: <Cast size={20} color="#fff" />,
         onPress: options?.presentCast ?? (() => {}),
       };
 


### PR DESCRIPTION
## Summary
- Removes the Google Cast integration (`react-native-google-cast` dependency, `CastContext` implementation, Cast UI in BottomControls / OutputDeviceSheet / playing bar) to drop proprietary Google dependencies for F-Droid.
- Removes the RNTP Android Cast dependency via a `patch-package` patch on `@rntp/player@5.6.0` (adds `patch-package` + `postinstall` script).
- Trims Android permissions and related `app.json` / manifest entries.

## Notes
- No `package.json` version bump, so merging will not trigger the release-on-version-bump workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)