### PR TITLE
Fix stale navigation in unified screens and distinguish owned vs. external albums

### DIFF
--- a/src/components/rows/ExternalAlbumRow/index.tsx
+++ b/src/components/rows/ExternalAlbumRow/index.tsx
@@ -5,7 +5,8 @@ import {
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
-import { Link, ArrowDownCircle } from 'lucide-react-native';
+import { Link, ArrowDownCircle, CloudOff } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
 
 import { ExternalAlbumBase } from '@/types';
 import ExternalAlbumOptions from '@/components/options/ExternalAlbumOptions';
@@ -17,9 +18,15 @@ type Props = {
   album: ExternalAlbumBase;
   artistName: string;
   onPress?: (album: ExternalAlbumBase) => void;
+  /** Show a "not in your library" badge for the common case (status.kind === 'none').
+   * Only meaningful where local and external rows can appear side by side in
+   * the same list — e.g. the merged Discography — since elsewhere (Search's
+   * source-grouped results) every row is already known to be external. */
+  showExternalBadge?: boolean;
 };
 
-const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress }) => {
+const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExternalBadge }) => {
+  const { t } = useTranslation();
   const { colors } = useTheme();
   const status = useExternalAlbumStatus(album);
 
@@ -57,6 +64,14 @@ const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress }) => {
                 <View style={styles.badge}>
                   <ArrowDownCircle size={12} color="#007AFF" />
                   <Text style={[styles.badgeText, styles.badgeTextBlue]}>{status.progress}%</Text>
+                </View>
+              )}
+              {status.kind === 'none' && showExternalBadge && (
+                <View style={styles.badge}>
+                  <CloudOff size={12} color={colors.subtext} />
+                  <Text style={[styles.badgeText, { color: colors.subtext }]}>
+                    {t('externalAlbum.serverStatus.notInLibrary')}
+                  </Text>
                 </View>
               )}
             </View>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -638,7 +638,8 @@
     },
     "serverStatus": {
       "onServer": "In Library",
-      "downloadingToServer": "Downloading to server · {{progress}}%"
+      "downloadingToServer": "Downloading to server · {{progress}}%",
+      "notInLibrary": "External"
     },
     "download": {
       "noDownloader": "No active downloader connected.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -624,7 +624,8 @@
     },
     "serverStatus": {
       "onServer": "Dans la bibliothèque",
-      "downloadingToServer": "Téléchargement vers le serveur · {{progress}}%"
+      "downloadingToServer": "Téléchargement vers le serveur · {{progress}}%",
+      "notInLibrary": "Externe"
     },
     "download": {
       "noDownloader": "Aucun gestionnaire de téléchargement actif connecté.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -624,7 +624,8 @@
     },
     "serverStatus": {
       "onServer": "ライブラリ内",
-      "downloadingToServer": "サーバーにダウンロード中 · {{progress}}%"
+      "downloadingToServer": "サーバーにダウンロード中 · {{progress}}%",
+      "notInLibrary": "外部"
     },
     "download": {
       "noDownloader": "有効なダウンローダーが接続されていません。",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -624,7 +624,8 @@
     },
     "serverStatus": {
       "onServer": "已在库中",
-      "downloadingToServer": "正在下载至服务器 · {{progress}}%"
+      "downloadingToServer": "正在下载至服务器 · {{progress}}%",
+      "notInLibrary": "外部"
     },
     "download": {
       "noDownloader": "未连接可用的下载工具。",

--- a/src/screens/album/index.tsx
+++ b/src/screens/album/index.tsx
@@ -27,10 +27,12 @@ const AlbumScreen: React.FC = () => {
   const { colors } = useTheme();
   const { albums } = useLibrary();
 
-  // Identity is resolved once, at mount, and frozen — same rationale as the
-  // unified Artist screen: a library-match resolving true mid-session must
-  // not flip an already-rendered external-only view into local mode
-  // underneath the user.
+  // Identity is re-resolved only when the route's own identity params change
+  // (a genuine navigation to a different album, including React Navigation
+  // reusing this screen instance instead of pushing a new one) — but not
+  // when `albums` changes on its own, e.g. a library sync completing in the
+  // background must not flip an already-rendered external-only view into
+  // local mode underneath the user.
   const resolvedLocalId = useMemo(() => {
     if (id) return id;
     if (!artist || !title) return null;
@@ -40,7 +42,7 @@ const AlbumScreen: React.FC = () => {
     );
     return match?.id ?? null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [id, artist, title, albumId]);
 
   const localResult = useAlbum(resolvedLocalId ?? '');
   const externalResult = useExternalAlbum(

--- a/src/screens/artist/components/Content/index.tsx
+++ b/src/screens/artist/components/Content/index.tsx
@@ -343,6 +343,7 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
         album={item.album}
         artistName={localArtist?.name ?? externalArtist?.name ?? ''}
         onPress={(album) => navigateToAlbum(album)}
+        showExternalBadge={!!localArtist}
       />
     )
   }, [colors, localArtist, externalArtist, navigation, navigateToAlbum, setVisibleAlbumsCount, setVisibleSinglesCount, t])

--- a/src/screens/artist/index.tsx
+++ b/src/screens/artist/index.tsx
@@ -28,10 +28,12 @@ const ArtistScreen: React.FC = () => {
   const { colors } = useTheme();
   const { artists } = useArtists();
 
-  // Identity is resolved once, at mount, and frozen — a library-match
-  // resolving true mid-session (e.g. library sync still in flight when this
-  // screen mounted) must not flip an already-rendered external-only view
-  // into local mode underneath the user.
+  // Identity is re-resolved only when the route's own identity params change
+  // (a genuine navigation to a different artist, including React Navigation
+  // reusing this screen instance instead of pushing a new one) — but not when
+  // `artists` changes on its own, e.g. a library sync completing in the
+  // background must not flip an already-rendered external-only view into
+  // local mode underneath the user.
   const resolvedLocalId = useMemo(() => {
     if (id) return id;
     if (forceExternal === 'true') return null;
@@ -42,7 +44,7 @@ const ArtistScreen: React.FC = () => {
     );
     return match?.id ?? null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [id, forceExternal, name, artistId, mbid]);
 
   const localResult = useArtist(resolvedLocalId ?? '');
   const externalResult = useExternalArtist(


### PR DESCRIPTION
## Summary
Follow-up to #158 (merged), fixing two regressions found in manual testing of the unified Artist/Album screens:

- **Navigation appeared to do nothing** from the Album screen's "More by {artist}" tiles, and from similar-artist rows on the Artist screen. Root cause: the unified screens resolve local-vs-external identity in a `useMemo` with an empty dependency array, frozen intentionally so a library sync completing in the background can't flip an already-open external view into local mode underneath the user. But React Navigation reuses the currently-focused screen instance and updates its params in place when navigating to a route you're already on — exactly what happens tapping "More by X" from an Album screen (pushes `albumView` → `albumView`) or a similar artist from the Artist screen (pushes `artistView` → `artistView`). With the memo frozen forever, the screen never re-resolved for the new target. Fixed by keying the memo on the route's own identity params (`id`/`name`/`mbid`/`artistId` for Artist, `id`/`artist`/`title`/`albumId` for Album) instead of `[]`, while still deliberately excluding the `artists`/`albums` library list from the deps — preserving the original protection while letting a genuine navigation re-resolve correctly.
- **No visual way to tell owned albums/singles apart from external "missing" releases** in the merged Discography list — a real gap, since the old separate external screen made this distinction obvious by construction. Added a small "External" badge (cloud-off icon + label) to `ExternalAlbumRow` for the plain not-in-library case, gated behind a new `showExternalBadge` prop so it only shows where the ambiguity actually exists (the merged Discography) and not in Search, where external results already sit under their own labelled section.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Testing
- `npx tsc --noEmit --pretty false`, `npm run lint`, `npx jest --ci` (24 suites, 97 tests) all pass.
- **Not yet verified on device/simulator** (none available in this environment) — please confirm the "More by" tiles, similar-artist rows (local/Deezer/Last.fm), and the new "External" badge in the merged Discography before merging.

## Related issues
Follow-up to #158, based on manual testing feedback after that PR merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZU7VB3X8gxz1gPWLwtTnB)_