### PR TITLE
Artist Discography design iteration + local-artist bio restore

### DIFF
--- a/src/components/rows/AlbumRow/index.tsx
+++ b/src/components/rows/AlbumRow/index.tsx
@@ -16,11 +16,15 @@ import { useSheetRef } from '@/utils/useSheetRef';
 type Props = {
   album: AlbumBase;
   onPress?: (album: AlbumBase) => void;
+  /** Replaces the album's own subtext line, e.g. the release year in the
+   * artist screen's chronological discography. */
+  subtextOverride?: string;
 };
 
 const AlbumRow: React.FC<Props> = ({
   album,
   onPress,
+  subtextOverride,
 }) => {
   const { colors } = useTheme();
   const optionsSheetRef = useSheetRef();
@@ -58,7 +62,7 @@ const AlbumRow: React.FC<Props> = ({
               numberOfLines={1}
               style={[styles.albumSubtext, { color: colors.subtext }]}
             >
-              {album.subtext}
+              {subtextOverride ?? album.subtext}
             </Text>
           </View>
         </TouchableOpacity>

--- a/src/components/rows/ExternalAlbumRow/index.tsx
+++ b/src/components/rows/ExternalAlbumRow/index.tsx
@@ -5,8 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
-import { Link, ArrowDownCircle, CloudOff } from 'lucide-react-native';
-import { useTranslation } from 'react-i18next';
+import { Link, ArrowDownCircle, Cloud } from 'lucide-react-native';
 
 import { ExternalAlbumBase } from '@/types';
 import ExternalAlbumOptions from '@/components/options/ExternalAlbumOptions';
@@ -18,15 +17,17 @@ type Props = {
   album: ExternalAlbumBase;
   artistName: string;
   onPress?: (album: ExternalAlbumBase) => void;
-  /** Show a "not in your library" badge for the common case (status.kind === 'none').
+  /** Show a "not in your library" glyph for the common case (status.kind === 'none').
    * Only meaningful where local and external rows can appear side by side in
    * the same list — e.g. the merged Discography — since elsewhere (Search's
    * source-grouped results) every row is already known to be external. */
   showExternalBadge?: boolean;
+  /** Replaces the album's own subtext line, e.g. the release year in the
+   * artist screen's chronological discography. */
+  subtextOverride?: string;
 };
 
-const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExternalBadge }) => {
-  const { t } = useTranslation();
+const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExternalBadge, subtextOverride }) => {
   const { colors } = useTheme();
   const status = useExternalAlbumStatus(album);
 
@@ -54,7 +55,7 @@ const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExt
                 numberOfLines={1}
                 style={[styles.albumSubtext, { color: colors.subtext }, styles.subtextFlex]}
               >
-                {album.subtext}
+                {subtextOverride ?? album.subtext}
               </Text>
 
               {status.kind === 'in_library' && (
@@ -67,12 +68,7 @@ const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExt
                 </View>
               )}
               {status.kind === 'none' && showExternalBadge && (
-                <View style={styles.badge}>
-                  <CloudOff size={12} color={colors.subtext} />
-                  <Text style={[styles.badgeText, { color: colors.subtext }]}>
-                    {t('externalAlbum.serverStatus.notInLibrary')}
-                  </Text>
-                </View>
+                <Cloud size={14} color={colors.subtext} />
               )}
             </View>
           </View>

--- a/src/features/sources/registry.ts
+++ b/src/features/sources/registry.ts
@@ -106,6 +106,7 @@ function releaseGroupToAlbumBase(rg: mb.MbReleaseGroup, fallbackArtist: string):
     artist: artistName,
     cover: releaseGroupToCover(rg),
     subtext: rg['first-release-date']?.slice(0, 4) ?? '',
+    releaseDate: rg['first-release-date'] ?? undefined,
     releaseType: rg['primary-type']?.toLowerCase() === 'single' ? 'single' : 'album',
     externalSource: 'musicbrainz',
     externalIds: { mbid: rg.id },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -638,8 +638,7 @@
     },
     "serverStatus": {
       "onServer": "In Library",
-      "downloadingToServer": "Downloading to server · {{progress}}%",
-      "notInLibrary": "External"
+      "downloadingToServer": "Downloading to server · {{progress}}%"
     },
     "download": {
       "noDownloader": "No active downloader connected.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -624,8 +624,7 @@
     },
     "serverStatus": {
       "onServer": "Dans la bibliothèque",
-      "downloadingToServer": "Téléchargement vers le serveur · {{progress}}%",
-      "notInLibrary": "Externe"
+      "downloadingToServer": "Téléchargement vers le serveur · {{progress}}%"
     },
     "download": {
       "noDownloader": "Aucun gestionnaire de téléchargement actif connecté.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -624,8 +624,7 @@
     },
     "serverStatus": {
       "onServer": "ライブラリ内",
-      "downloadingToServer": "サーバーにダウンロード中 · {{progress}}%",
-      "notInLibrary": "外部"
+      "downloadingToServer": "サーバーにダウンロード中 · {{progress}}%"
     },
     "download": {
       "noDownloader": "有効なダウンローダーが接続されていません。",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -624,8 +624,7 @@
     },
     "serverStatus": {
       "onServer": "已在库中",
-      "downloadingToServer": "正在下载至服务器 · {{progress}}%",
-      "notInLibrary": "外部"
+      "downloadingToServer": "正在下载至服务器 · {{progress}}%"
     },
     "download": {
       "noDownloader": "未连接可用的下载工具。",

--- a/src/screens/artist/components/Content/BioSection.tsx
+++ b/src/screens/artist/components/Content/BioSection.tsx
@@ -7,8 +7,9 @@ type Props = {
   biography?: string
 }
 
-// External-only, no local fallback attempted — self-hosted servers don't
-// carry artist biography text, so there's nothing genuine to show locally.
+// The biography always comes from an external source (Deezer in local mode,
+// the resolved external artist otherwise) — self-hosted servers don't carry
+// artist biography text.
 export default function BioSection({ biography }: Props) {
   const { colors } = useTheme()
   const { t } = useTranslation()

--- a/src/screens/artist/components/Content/discography.test.ts
+++ b/src/screens/artist/components/Content/discography.test.ts
@@ -1,0 +1,90 @@
+import { compareByReleaseYearDesc, releaseYearLabel, releaseYearOf } from './discography'
+import type { AlbumBase, ExternalAlbumBase } from '@/types'
+
+const local = (id: string, year: number): AlbumBase => ({
+  id,
+  title: `Album ${id}`,
+  cover: { kind: 'none' },
+  subtext: '',
+  artist: { id: 'a1', name: 'Artist', cover: { kind: 'none' }, subtext: '' },
+  year,
+  genres: [],
+  created: new Date(0),
+})
+
+const external = (id: string, overrides: Partial<ExternalAlbumBase> = {}): ExternalAlbumBase => ({
+  id,
+  title: `Album ${id}`,
+  artist: 'Artist',
+  cover: { kind: 'none' },
+  subtext: '',
+  ...overrides,
+})
+
+describe('releaseYearOf', () => {
+  it('reads the year field from local albums', () => {
+    expect(releaseYearOf(local('l1', 1997))).toBe(1997)
+  })
+
+  it('treats a zero local year as unknown', () => {
+    expect(releaseYearOf(local('l1', 0))).toBeNull()
+  })
+
+  it('reads releaseDate from external albums', () => {
+    expect(releaseYearOf(external('e1', { releaseDate: '2007-10-10' }))).toBe(2007)
+  })
+
+  it('falls back to a year-shaped subtext when releaseDate is missing', () => {
+    expect(releaseYearOf(external('e1', { subtext: '2000' }))).toBe(2000)
+  })
+
+  it('returns null when nothing date-like is available', () => {
+    expect(releaseYearOf(external('e1'))).toBeNull()
+  })
+})
+
+describe('compareByReleaseYearDesc', () => {
+  it('sorts newest first across local and external albums', () => {
+    const items = [
+      local('l-1997', 1997),
+      external('e-2007', { releaseDate: '2007-10-10' }),
+      local('l-2016', 2016),
+      external('e-2000', { subtext: '2000' }),
+    ]
+
+    expect([...items].sort(compareByReleaseYearDesc).map(a => a.id))
+      .toEqual(['l-2016', 'e-2007', 'e-2000', 'l-1997'])
+  })
+
+  it('sinks unknown years to the end', () => {
+    const items = [
+      external('e-unknown'),
+      local('l-1997', 1997),
+    ]
+
+    expect([...items].sort(compareByReleaseYearDesc).map(a => a.id))
+      .toEqual(['l-1997', 'e-unknown'])
+  })
+
+  it('keeps insertion order on ties so owned stays ahead of external', () => {
+    const items = [
+      local('l-2007', 2007),
+      external('e-2007', { releaseDate: '2007-01-01' }),
+    ]
+
+    expect([...items].sort(compareByReleaseYearDesc).map(a => a.id))
+      .toEqual(['l-2007', 'e-2007'])
+  })
+})
+
+describe('releaseYearLabel', () => {
+  it('formats a known year', () => {
+    expect(releaseYearLabel(local('l1', 1997))).toBe('1997')
+    expect(releaseYearLabel(external('e1', { releaseDate: '2007-10-10' }))).toBe('2007')
+  })
+
+  it('returns null for unknown years so callers can fall back', () => {
+    expect(releaseYearLabel(local('l1', 0))).toBeNull()
+    expect(releaseYearLabel(external('e1'))).toBeNull()
+  })
+})

--- a/src/screens/artist/components/Content/discography.ts
+++ b/src/screens/artist/components/Content/discography.ts
@@ -1,0 +1,34 @@
+import type { AlbumBase, ExternalAlbumBase } from '@/types';
+
+// Local albums carry a numeric `year`; external ones carry an ISO-ish
+// `releaseDate` (Deezer, MusicBrainz) with the bare year in `subtext` as a
+// fallback. Either can be absent or zero when the upstream has no date.
+export function releaseYearOf(album: AlbumBase | ExternalAlbumBase): number | null {
+  if ('year' in album) return album.year > 0 ? album.year : null;
+  const raw = album.releaseDate ?? album.subtext;
+  const year = parseInt(String(raw).slice(0, 4), 10);
+  return Number.isFinite(year) && year > 0 ? year : null;
+}
+
+// Row subtext for the merged discography: the release year, since that's the
+// sort key and every row already belongs to the same artist. Null when the
+// year is unknown so callers can fall back to the album's own subtext.
+export function releaseYearLabel(album: AlbumBase | ExternalAlbumBase): string | null {
+  const year = releaseYearOf(album);
+  return year === null ? null : String(year);
+}
+
+// Newest first, unknown years sink to the end. Ties keep insertion order
+// (Array.prototype.sort is stable), so owned releases stay ahead of external
+// ones from the same year.
+export function compareByReleaseYearDesc(
+  a: AlbumBase | ExternalAlbumBase,
+  b: AlbumBase | ExternalAlbumBase
+): number {
+  const ya = releaseYearOf(a);
+  const yb = releaseYearOf(b);
+  if (ya === null && yb === null) return 0;
+  if (ya === null) return 1;
+  if (yb === null) return -1;
+  return yb - ya;
+}

--- a/src/screens/artist/components/Content/index.tsx
+++ b/src/screens/artist/components/Content/index.tsx
@@ -13,6 +13,7 @@ import { useArtistAlbums, useSimilarArtists } from '@/hooks/artists'
 import { useArtistTopTracks } from '@/hooks/artists/useArtistTopTracks'
 import { useArtistExternalDiscography } from '@/hooks/artists/useArtistExternalDiscography'
 import { matchAlbumToLibrary } from '@/hooks/libraryMatch'
+import { compareByReleaseYearDesc, releaseYearLabel } from './discography'
 import { useTracks } from '@/hooks/tracks'
 import MediaTile from '@/screens/home/components/MediaTile'
 import MostPlayedSection from './MostPlayedSection'
@@ -209,10 +210,11 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
       const albums = localAlbums.filter(album => !isSingleOrEp(album, songCountByAlbumId.get(album.id) ?? 0))
       const singles = localAlbums.filter(album => isSingleOrEp(album, songCountByAlbumId.get(album.id) ?? 0))
 
-      // Owned releases first, then whatever the enabled external sources
-      // have for this artist that isn't already matched to something owned
-      // — the row itself (ExternalAlbumRow) double-checks "already in
-      // library" independently as a safety net if this dedup misses an edge case.
+      // Owned releases merged chronologically with whatever the enabled
+      // external sources have for this artist that isn't already matched to
+      // something owned — the row itself (ExternalAlbumRow) double-checks
+      // "already in library" independently as a safety net if this dedup
+      // misses an edge case.
       const missingAlbums = (externalDiscography?.albums ?? [])
         .filter(ext => !matchAlbumToLibrary(ext, localAlbums))
       const missingSingles = (externalDiscography?.singles ?? [])
@@ -221,11 +223,11 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
       const albumItems: ArtistContentItem[] = [
         ...albums.map(album => ({ kind: 'localAlbum' as const, id: `album-${album.id}`, album })),
         ...missingAlbums.map(album => ({ kind: 'externalAlbum' as const, id: `album-ext-${album.id}`, album })),
-      ]
+      ].sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
       const singleItems: ArtistContentItem[] = [
         ...singles.map(album => ({ kind: 'localAlbum' as const, id: `single-${album.id}`, album })),
         ...missingSingles.map(album => ({ kind: 'externalAlbum' as const, id: `single-ext-${album.id}`, album })),
-      ]
+      ].sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
 
       if (albumItems.length > 0) {
         rows.push({ kind: 'section', id: 'albums-section', title: t('artist.sections.albums') })
@@ -248,21 +250,24 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
     } else if (externalArtist) {
       rows.push({ kind: 'popularOnDeezer', id: 'popular-on-deezer' })
 
-      if (externalArtist.albums.length > 0) {
+      const sortedAlbums = [...externalArtist.albums].sort(compareByReleaseYearDesc)
+      const sortedSingles = [...externalArtist.singles].sort(compareByReleaseYearDesc)
+
+      if (sortedAlbums.length > 0) {
         rows.push({ kind: 'section', id: 'albums-section', title: t('artist.sections.albums') })
-        const visibleAlbums = externalArtist.albums.slice(0, visibleAlbumsCount)
+        const visibleAlbums = sortedAlbums.slice(0, visibleAlbumsCount)
         rows.push(...visibleAlbums.map(album => ({ kind: 'externalAlbum' as const, id: `album-${album.id}`, album })))
-        if (visibleAlbumsCount < externalArtist.albums.length) {
-          rows.push({ kind: 'showMore', id: 'show-more-albums', target: 'albums', remaining: externalArtist.albums.length - visibleAlbumsCount })
+        if (visibleAlbumsCount < sortedAlbums.length) {
+          rows.push({ kind: 'showMore', id: 'show-more-albums', target: 'albums', remaining: sortedAlbums.length - visibleAlbumsCount })
         }
       }
 
-      if (externalArtist.singles.length > 0) {
+      if (sortedSingles.length > 0) {
         rows.push({ kind: 'section', id: 'singles-section', title: t('artist.sections.singles') })
-        const visibleSingles = externalArtist.singles.slice(0, visibleSinglesCount)
+        const visibleSingles = sortedSingles.slice(0, visibleSinglesCount)
         rows.push(...visibleSingles.map(album => ({ kind: 'externalAlbum' as const, id: `single-${album.id}`, album })))
-        if (visibleSinglesCount < externalArtist.singles.length) {
-          rows.push({ kind: 'showMore', id: 'show-more-singles', target: 'singles', remaining: externalArtist.singles.length - visibleSinglesCount })
+        if (visibleSinglesCount < sortedSingles.length) {
+          rows.push({ kind: 'showMore', id: 'show-more-singles', target: 'singles', remaining: sortedSingles.length - visibleSinglesCount })
         }
       }
 
@@ -290,7 +295,12 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
     }
 
     if (item.kind === 'bio') {
-      return <BioSection biography={localArtist ? undefined : externalArtist?.biography} />
+      return (
+        <BioSectionResolver
+          localArtist={localArtist}
+          externalArtist={externalArtist}
+        />
+      )
     }
 
     if (item.kind === 'section') {
@@ -334,6 +344,7 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
         <AlbumRow
           album={item.album}
           onPress={(album) => navigation.navigate('albumView', { id: album.id })}
+          subtextOverride={releaseYearLabel(item.album) ?? undefined}
         />
       )
     }
@@ -344,6 +355,7 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
         artistName={localArtist?.name ?? externalArtist?.name ?? ''}
         onPress={(album) => navigateToAlbum(album)}
         showExternalBadge={!!localArtist}
+        subtextOverride={releaseYearLabel(item.album) ?? undefined}
       />
     )
   }, [colors, localArtist, externalArtist, navigation, navigateToAlbum, setVisibleAlbumsCount, setVisibleSinglesCount, t])
@@ -391,6 +403,25 @@ function PopularOnDeezerSectionResolver({ localArtist, externalArtist }: {
     )
   }
   return null
+}
+
+// Same per-mode plumbing as PopularOnDeezerSectionResolver: local mode pulls
+// the Deezer biography via useArtistTopTracks (the same query the resolver
+// above runs, so react-query dedupes it), external mode already has it on
+// the artist. Gated by the Deezer Top Tracks setting in local mode, matching
+// the pre-unification behavior where the bio lived inside TopTracksSection.
+function BioSectionResolver({ localArtist, externalArtist }: {
+  localArtist: Artist | null
+  externalArtist: ExternalArtist | null
+}) {
+  const deezerTopTracksEnabled = useDeezerTopTracksEnabled()
+  const { biography: localBiography } = useArtistTopTracks({
+    name: localArtist?.name ?? '',
+    mbid: localArtist?.mbid,
+    enabled: !!localArtist && deezerTopTracksEnabled,
+  })
+
+  return <BioSection biography={localArtist ? localBiography : externalArtist?.biography} />
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary

Follow-up to the unified Artist/Album screens (#158) — iterates on the Albums / Singles & EPs sections and restores a behavior lost in the unification.

- **Restore Deezer biography on local artist screens.** The old TopTracksSection showed it; the unified screen only passed a bio in external mode. A `BioSectionResolver` (mirroring `PopularOnDeezerSectionResolver`) fetches it in local mode, gated by the Deezer Top Tracks setting, deduped by react-query against the Popular section's identical query.
- **Chronological discography.** Owned and external releases now interleave newest-first within Albums and Singles & EPs (both local and external artist modes). Unknown years sink to the end; year ties keep owned ahead of external. Sort logic lives in a pure `discography.ts` helper with unit tests.
- **Year as row subtext.** The merged list previously showed three subtext formats side by side (`Album • Artist` local, artist name from Deezer, year from MusicBrainz). Discography rows now all show the release year — the sort key — via an optional `subtextOverride` prop; Search and other callers unchanged.
- **Icon-only external glyph.** The `CloudOff` + "External" text badge is now a single `Cloud` icon in subtext color, consistent with the icon-only green `Link` used for "in library" (and semantically right-side-up: the release *is* in the cloud, not local). Unused `notInLibrary` string removed from all four locales.
- **MusicBrainz `releaseDate` mapping.** Release groups now copy `first-release-date` into `releaseDate` so MB-sourced releases sort correctly instead of sinking as undated.

## Testing

- `npx jest --ci`: 25 suites / 107 tests pass (10 new for the discography helpers)
- `npx tsc --noEmit` and `npm run lint`: clean
- Not exercised on-device; worth a quick manual pass on an artist screen: bio visible on a local artist with Deezer Top Tracks on, chronological order with cloud glyphs on external rows, and untagged (`year: 0`) albums sitting at the section bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)