### PR TITLE
Refine shared app design primitives

### DIFF
--- a/src/components/DetailHeader.tsx
+++ b/src/components/DetailHeader.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { ChevronLeft } from 'lucide-react-native';
+import { useNavigation } from '@react-navigation/native';
+import { MediaImage } from '@/components/MediaImage';
+import { useTheme } from '@/hooks/useTheme';
+import { controlSize, spacing, typography } from '@/constants/design';
+import type { CoverSource } from '@/types';
+
+type DetailHeaderProps = {
+  title: string;
+  cover: CoverSource;
+  rightAction?: React.ReactNode;
+  meta?: React.ReactNode;
+  status?: React.ReactNode;
+  actions?: React.ReactNode;
+};
+
+export function DetailHeader({
+  title,
+  cover,
+  rightAction,
+  meta,
+  status,
+  actions,
+}: DetailHeaderProps) {
+  const navigation = useNavigation<any>();
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerRow}>
+        <TouchableOpacity
+          testID="detail-back-button"
+          onPress={() => navigation.goBack()}
+          style={styles.headerButton}
+        >
+          <ChevronLeft size={24} color={colors.secondary} />
+        </TouchableOpacity>
+
+        <View pointerEvents="none" style={styles.headerTitleWrapper}>
+          <Text style={[styles.headerTitle, { color: colors.secondary }]} numberOfLines={1}>
+            {title}
+          </Text>
+        </View>
+
+        {rightAction ?? <View style={styles.headerButton} />}
+      </View>
+
+      <View style={styles.coverWrapper}>
+        <MediaImage cover={cover} size="detail" style={styles.coverImage} />
+      </View>
+
+      <View style={styles.titleInfo}>
+        <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={2}>
+          {title}
+        </Text>
+        {meta}
+      </View>
+
+      {status}
+
+      {actions}
+    </View>
+  );
+}
+
+type DetailMetaRowProps = {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function DetailMetaRow({ children, style }: DetailMetaRowProps) {
+  return <View style={[styles.metaRow, style]}>{children}</View>;
+}
+
+export function DetailMetaDot() {
+  const { colors } = useTheme();
+  return (
+    <Text style={[styles.metaDot, { color: colors.subtext }]} numberOfLines={1}>
+      •
+    </Text>
+  );
+}
+
+type DetailMetaTextProps = {
+  children: React.ReactNode;
+};
+
+export function DetailMetaText({ children }: DetailMetaTextProps) {
+  const { colors } = useTheme();
+  return (
+    <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
+      {children}
+    </Text>
+  );
+}
+
+type DetailActionRowProps = {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function DetailActionRow({ children, style }: DetailActionRowProps) {
+  return (
+    <View style={[styles.actionsRow, style]}>
+      <View style={styles.actions}>{children}</View>
+    </View>
+  );
+}
+
+type DetailCircleActionProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function DetailCircleAction({ children, onPress, disabled, style }: DetailCircleActionProps) {
+  const { colors } = useTheme();
+  return (
+    <TouchableOpacity
+      style={[styles.secondaryButton, { backgroundColor: colors.card }, style]}
+      onPress={onPress}
+      disabled={disabled}
+      activeOpacity={0.7}
+    >
+      {children}
+    </TouchableOpacity>
+  );
+}
+
+type DetailPlayActionProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function DetailPlayAction({ children, onPress, disabled, style }: DetailPlayActionProps) {
+  const { colors } = useTheme();
+  return (
+    <TouchableOpacity
+      style={[styles.playButton, { backgroundColor: colors.themeColor }, style]}
+      onPress={onPress}
+      disabled={disabled}
+      activeOpacity={0.7}
+    >
+      {children}
+    </TouchableOpacity>
+  );
+}
+
+type DetailHeaderIconButtonProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+};
+
+export function DetailHeaderIconButton({ children, onPress }: DetailHeaderIconButtonProps) {
+  return (
+    <TouchableOpacity onPress={onPress} style={styles.headerButton} activeOpacity={0.7}>
+      {children}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 0,
+    alignItems: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.page,
+    paddingVertical: 12,
+    width: '100%',
+  },
+  headerTitleWrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    maxWidth: '60%',
+  },
+  headerButton: {
+    padding: 6,
+    width: controlSize.iconCompact,
+  },
+  coverWrapper: {
+    width: 280,
+    height: 280,
+    borderRadius: 16,
+    marginTop: 32,
+    marginBottom: 24,
+    overflow: 'hidden',
+  },
+  coverImage: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 16,
+  },
+  titleInfo: {
+    width: '100%',
+    marginBottom: 20,
+    alignItems: 'center',
+  },
+  title: {
+    ...typography.detailTitle,
+    marginBottom: 6,
+    textAlign: 'center',
+  },
+  subtext: {
+    fontSize: 14,
+  },
+  metaDot: {
+    fontSize: 14,
+    marginHorizontal: 6,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'center',
+    flexWrap: 'nowrap',
+    maxWidth: '94%',
+    marginTop: 4,
+  },
+  actionsRow: {
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.controlGap,
+  },
+  secondaryButton: {
+    width: controlSize.detailSecondary,
+    height: controlSize.detailSecondary,
+    borderRadius: controlSize.detailSecondary / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  playButton: {
+    borderRadius: 22,
+    width: controlSize.detailPrimaryWidth,
+    height: controlSize.detailPrimaryHeight,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/components/IconActionButton.tsx
+++ b/src/components/IconActionButton.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  TouchableOpacity,
+  type GestureResponderEvent,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { controlSize } from '@/constants/design';
+
+type Props = {
+  icon: React.ReactNode;
+  onPress?: (event: GestureResponderEvent) => void;
+  accessibilityLabel: string;
+  disabled?: boolean;
+  loading?: boolean;
+  size?: 'compact' | 'default';
+  style?: StyleProp<ViewStyle>;
+};
+
+export default function IconActionButton({
+  icon,
+  onPress,
+  accessibilityLabel,
+  disabled,
+  loading,
+  size = 'default',
+  style,
+}: Props) {
+  const { colors } = useTheme();
+  const isDisabled = disabled || loading;
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.button,
+        size === 'compact' ? styles.compact : styles.default,
+        isDisabled && styles.disabled,
+        style,
+      ]}
+      onPress={onPress}
+      disabled={isDisabled}
+      activeOpacity={0.7}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
+    >
+      {loading ? <ActivityIndicator size="small" color={colors.subtext} /> : icon}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  default: {
+    width: controlSize.iconDefault,
+    height: controlSize.iconDefault,
+    borderRadius: controlSize.iconDefault / 2,
+  },
+  compact: {
+    width: controlSize.iconCompact,
+    height: controlSize.iconCompact,
+    borderRadius: controlSize.iconCompact / 2,
+  },
+  disabled: {
+    opacity: 0.45,
+  },
+});

--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { MediaImage } from '@/components/MediaImage';
+import { useTheme } from '@/hooks/useTheme';
+import { controlSize, radius, spacing, typography } from '@/constants/design';
+import type { CoverSource } from '@/types';
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  cover: CoverSource;
+  onPress?: () => void;
+  disabled?: boolean;
+  trailing?: React.ReactNode;
+  roundedCover?: boolean;
+  variant?: 'default' | 'compact';
+  contentStyle?: StyleProp<ViewStyle>;
+  rowStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
+};
+
+export default function MediaListRow({
+  title,
+  subtitle,
+  cover,
+  onPress,
+  disabled,
+  trailing,
+  roundedCover,
+  variant = 'default',
+  contentStyle,
+  rowStyle,
+  style,
+}: Props) {
+  const { colors } = useTheme();
+  const isCompact = variant === 'compact';
+
+  return (
+    <View style={[styles.wrapper, style]}>
+      <View style={[styles.row, isCompact && styles.compactRow, rowStyle]}>
+        <TouchableOpacity
+          style={[styles.content, contentStyle]}
+          onPress={onPress}
+          disabled={disabled || !onPress}
+          activeOpacity={disabled ? 1 : 0.7}
+        >
+          <MediaImage
+            cover={cover}
+            size={isCompact ? 'thumb' : 'grid'}
+            style={[
+              styles.cover,
+              isCompact && styles.compactCover,
+              roundedCover && (isCompact ? styles.compactCoverRounded : styles.coverRounded),
+            ]}
+          />
+
+          <View style={styles.textContainer}>
+            <Text
+              numberOfLines={1}
+              style={[isCompact ? styles.compactTitle : styles.title, { color: colors.secondary }]}
+            >
+              {title}
+            </Text>
+
+            {subtitle !== undefined && (
+              <Text
+                numberOfLines={1}
+                style={[isCompact ? styles.compactSubtitle : styles.subtitle, { color: colors.subtext }]}
+              >
+                {subtitle}
+              </Text>
+            )}
+          </View>
+        </TouchableOpacity>
+
+        {trailing}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    paddingHorizontal: spacing.page,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  compactRow: {
+    marginBottom: 0,
+    paddingVertical: 10,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  cover: {
+    width: controlSize.mediaRowArt,
+    height: controlSize.mediaRowArt,
+    borderRadius: radius.thumb,
+  },
+  compactCover: {
+    width: controlSize.compactMediaRowArt,
+    height: controlSize.compactMediaRowArt,
+  },
+  coverRounded: {
+    borderRadius: controlSize.mediaRowArt / 2,
+  },
+  compactCoverRounded: {
+    borderRadius: controlSize.compactMediaRowArt / 2,
+  },
+  textContainer: {
+    flex: 1,
+    marginLeft: spacing.rowGap,
+  },
+  title: typography.rowTitle,
+  compactTitle: typography.compactRowTitle,
+  subtitle: {
+    ...typography.rowSubtitle,
+    marginTop: 2,
+  },
+  compactSubtitle: {
+    ...typography.compactRowSubtitle,
+    marginTop: 1,
+  },
+});

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTheme } from '@/hooks/useTheme';
+import { spacing, typography } from '@/constants/design';
+
+type Props = {
+  title: string;
+  badge?: React.ReactNode;
+  action?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+export default function SectionHeader({ title, badge, action, style }: Props) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.row, style]}>
+      {badge}
+      <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={1}>
+        {title}
+      </Text>
+      {action}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.page,
+    marginBottom: 12,
+    gap: 8,
+  },
+  title: {
+    flex: 1,
+    ...typography.sectionTitle,
+  },
+});

--- a/src/components/StatusBanner.tsx
+++ b/src/components/StatusBanner.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { X } from 'lucide-react-native';
+import { useTheme } from '@/hooks/useTheme';
+
+type Props = {
+  icon: ReactNode;
+  text: string;
+  /** Text color; defaults to the theme subtext color. */
+  color?: string;
+  /** Render a small ✕ and let the user dismiss the banner for this mount. */
+  closable?: boolean;
+  style?: ViewStyle;
+  testID?: string;
+};
+
+// Small inline status pill used on detail screens — the same visual as the
+// album header's "In Library" / "Downloading to server" row, extracted so
+// other statuses (server unreachable, offline) share one look. Dismissal is
+// per-mount state: the banner returns on the next visit, which is right for
+// transient conditions like connectivity.
+export default function StatusBanner({ icon, text, color, closable, style, testID }: Props) {
+  const { isDarkMode, colors } = useTheme();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  const background = isDarkMode ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)';
+  const textColor = color ?? colors.subtext;
+
+  return (
+    <View style={[styles.row, { backgroundColor: background }, style]} testID={testID}>
+      {icon}
+      <Text style={[styles.text, { color: textColor }]} numberOfLines={2}>
+        {text}
+      </Text>
+      {closable && (
+        <TouchableOpacity
+          onPress={() => setDismissed(true)}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          testID={testID ? `${testID}-close` : undefined}
+        >
+          <X size={14} color={textColor} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  text: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});

--- a/src/components/rows/AlbumRow/index.tsx
+++ b/src/components/rows/AlbumRow/index.tsx
@@ -1,15 +1,14 @@
 import React, { memo, useCallback } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
-  TouchableOpacity,
 } from 'react-native';
 import { Ellipsis } from 'lucide-react-native';
 
 import { AlbumBase } from '@/types';
 import AlbumOptions from '@/components/options/AlbumOptions';
-import { MediaImage } from '@/components/MediaImage';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import { useTheme } from '@/hooks/useTheme';
 import { useSheetRef } from '@/utils/useSheetRef';
 
@@ -37,48 +36,21 @@ const AlbumRow: React.FC<Props> = ({
 
   return (
     <View style={styles.wrapper}>
-      <View style={styles.albumItem}>
-        <TouchableOpacity
-          style={styles.albumContent}
-          onPress={handlePress}
-        >
-          <MediaImage
-            cover={album.cover}
-            size="grid"
-            style={styles.cover}
-          />
-
-          <View style={styles.albumTextContainer}>
-            <View style={styles.titleRow}>
-              <Text
-                numberOfLines={1}
-                style={[styles.albumTitle, { color: colors.secondary }]}
-              >
-                {album.title}
-              </Text>
-            </View>
-
-            <Text
-              numberOfLines={1}
-              style={[styles.albumSubtext, { color: colors.subtext }]}
-            >
-              {subtextOverride ?? album.subtext}
-            </Text>
-          </View>
-        </TouchableOpacity>
-
-        <View style={styles.optionsContainer}>
-          <TouchableOpacity
+      <MediaListRow
+        title={album.title}
+        subtitle={subtextOverride ?? album.subtext}
+        cover={album.cover}
+        onPress={handlePress}
+        trailing={
+          <IconActionButton
+            icon={<Ellipsis size={24} color={colors.secondary} />}
             onPress={handleOptionsPress}
-            style={styles.optionButton}
-          >
-            <Ellipsis
-              size={24}
-              color={colors.secondary}
-            />
-          </TouchableOpacity>
-        </View>
-      </View>
+            accessibilityLabel="Album options"
+            size="compact"
+          />
+        }
+        style={styles.row}
+      />
 
       <AlbumOptions
         ref={optionsSheetRef}
@@ -93,44 +65,9 @@ export default memo(AlbumRow);
 
 const styles = StyleSheet.create({
   wrapper: {
+    flex: 1,
+  },
+  row: {
     paddingHorizontal: 16,
-  },
-  cover: {
-    width: 64,
-    height: 64,
-    borderRadius: 6,
-  },
-  albumItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  albumContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  albumTextContainer: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  albumTitle: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  albumSubtext: {
-    fontSize: 14,
-    marginTop: 2,
-  },
-  optionsContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  optionButton: {
-    padding: 8,
   },
 });

--- a/src/components/rows/ArtistRow/index.tsx
+++ b/src/components/rows/ArtistRow/index.tsx
@@ -1,14 +1,13 @@
 import React, { memo, useCallback } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
-  TouchableOpacity,
 } from 'react-native';
 import { Ellipsis } from 'lucide-react-native';
 import { Artist } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import ArtistOptions from '@/components/options/ArtistOptions';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { useSheetRef } from '@/utils/useSheetRef';
@@ -34,46 +33,22 @@ const ArtistRow: React.FC<Props> = ({ artist, onPress, rounded = false }) => {
   return (
     <>
       <View style={styles.wrapper}>
-        <View style={styles.rowItem}>
-          <TouchableOpacity
-            style={styles.rowContent}
-            onPress={handlePress}
-          >
-            <MediaImage
-              cover={artist.cover}
-              size="grid"
-              style={[styles.cover, rounded && styles.coverRounded]}
-            />
-
-            <View style={styles.textContainer}>
-              <Text
-                numberOfLines={1}
-                style={[styles.title, { color: colors.secondary }]}
-              >
-                {artist.name}
-              </Text>
-
-              <Text
-                numberOfLines={1}
-                style={[styles.subtext, { color: colors.subtext }]}
-              >
-                {artist.subtext === 'Artist' ? t('common.artist') : artist.subtext}
-              </Text>
-            </View>
-          </TouchableOpacity>
-
-          <View style={styles.optionsContainer}>
-            <TouchableOpacity
+        <MediaListRow
+          title={artist.name}
+          subtitle={artist.subtext === 'Artist' ? t('common.artist') : artist.subtext}
+          cover={artist.cover}
+          onPress={handlePress}
+          roundedCover={rounded}
+          trailing={
+            <IconActionButton
+              icon={<Ellipsis size={24} color={colors.secondary} />}
               onPress={handleOpenOptions}
-              style={styles.optionButton}
-            >
-              <Ellipsis
-                size={24}
-                color={colors.secondary}
-              />
-            </TouchableOpacity>
-          </View>
-        </View>
+              accessibilityLabel="Artist options"
+              size="compact"
+            />
+          }
+          style={styles.row}
+        />
       </View>
 
       <ArtistOptions ref={sheetRef} artist={artist} />
@@ -85,43 +60,9 @@ export default memo(ArtistRow);
 
 const styles = StyleSheet.create({
   wrapper: {
+    flex: 1,
+  },
+  row: {
     paddingHorizontal: 16,
-  },
-  cover: {
-    width: 64,
-    height: 64,
-    borderRadius: 6,
-  },
-  coverRounded: {
-    borderRadius: 32,
-  },
-  rowItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  rowContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  textContainer: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  title: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  subtext: {
-    fontSize: 14,
-    marginTop: 2,
-  },
-  optionsContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  optionButton: {
-    padding: 8,
   },
 });

--- a/src/components/rows/PlaylistRow/index.tsx
+++ b/src/components/rows/PlaylistRow/index.tsx
@@ -1,16 +1,15 @@
 import React, { memo, useCallback } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
-  TouchableOpacity,
 } from 'react-native';
 import { Ellipsis } from 'lucide-react-native';
 
 import { PlaylistBase } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import { useTheme } from '@/hooks/useTheme';
 import PlaylistOptions from '@/components/options/PlaylistOptions';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import { useSheetRef } from '@/utils/useSheetRef';
 
 type Props = {
@@ -30,46 +29,21 @@ const PlaylistRow: React.FC<Props> = ({ playlist, onPress }) => {
 
   return (
     <View style={styles.wrapper}>
-      <View style={styles.rowItem}>
-        <TouchableOpacity
-          style={styles.rowContent}
-          onPress={handlePress}
-        >
-          <MediaImage
-            cover={playlist.cover}
-            size="grid"
-            style={styles.cover}
-          />
-
-          <View style={styles.textContainer}>
-            <Text
-              numberOfLines={1}
-              style={[styles.title, { color: colors.secondary }]}
-            >
-              {playlist.title}
-            </Text>
-
-            <Text
-              numberOfLines={1}
-              style={[styles.subtext, { color: colors.subtext }]}
-            >
-              {playlist.subtext}
-            </Text>
-          </View>
-        </TouchableOpacity>
-
-        <View style={styles.optionsContainer}>
-          <TouchableOpacity
+      <MediaListRow
+        title={playlist.title}
+        subtitle={playlist.subtext}
+        cover={playlist.cover}
+        onPress={handlePress}
+        trailing={
+          <IconActionButton
+            icon={<Ellipsis size={24} color={colors.secondary} />}
             onPress={handleOptionsPress}
-            style={styles.optionButton}
-          >
-            <Ellipsis
-              size={24}
-              color={colors.secondary}
-            />
-          </TouchableOpacity>
-        </View>
-      </View>
+            accessibilityLabel="Playlist options"
+            size="compact"
+          />
+        }
+        style={styles.row}
+      />
 
       <PlaylistOptions
         ref={optionsSheetRef}
@@ -84,40 +58,9 @@ export default memo(PlaylistRow);
 
 const styles = StyleSheet.create({
   wrapper: {
+    flex: 1,
+  },
+  row: {
     paddingHorizontal: 16,
-  },
-  cover: {
-    width: 64,
-    height: 64,
-    borderRadius: 6,
-  },
-  rowItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  rowContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  textContainer: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  title: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  subtext: {
-    fontSize: 14,
-    marginTop: 2,
-  },
-  optionsContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  optionButton: {
-    padding: 8,
   },
 });

--- a/src/constants/design.ts
+++ b/src/constants/design.ts
@@ -1,0 +1,30 @@
+export const spacing = {
+  page: 16,
+  rowGap: 12,
+  controlGap: 10,
+} as const;
+
+export const radius = {
+  thumb: 6,
+  card: 12,
+  pill: 999,
+} as const;
+
+export const typography = {
+  detailTitle: { fontSize: 24, fontWeight: '600' as const },
+  sectionTitle: { fontSize: 20, fontWeight: '600' as const },
+  rowTitle: { fontSize: 16, fontWeight: '500' as const },
+  rowSubtitle: { fontSize: 14 },
+  compactRowTitle: { fontSize: 15, fontWeight: '500' as const },
+  compactRowSubtitle: { fontSize: 13 },
+} as const;
+
+export const controlSize = {
+  iconDefault: 44,
+  iconCompact: 36,
+  detailSecondary: 40,
+  detailPrimaryWidth: 112,
+  detailPrimaryHeight: 48,
+  mediaRowArt: 64,
+  compactMediaRowArt: 44,
+} as const;

--- a/src/screens/album/components/Header/index.tsx
+++ b/src/screens/album/components/Header/index.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import {
-  View,
-  Text,
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
@@ -12,20 +10,18 @@ import Animated, {
   withSequence,
   withSpring,
 } from 'react-native-reanimated';
-import { ChevronLeft, Ellipsis, Shuffle, Play, Check, Download, CloudDownload, Link } from 'lucide-react-native';
+import { Ellipsis, Shuffle, Play, Check, Download, CloudDownload, Link } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import { Album, ExternalAlbum, Playlist, Song } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import AlbumOptions from '@/components/options/AlbumOptions';
 import DownloadSheet from '@/components/options/DownloadSheet';
+import StatusBanner from '@/components/StatusBanner';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
 
 import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useDownload } from '@/contexts/DownloadContext';
-import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors';
 import { useTheme } from '@/hooks/useTheme';
 import { useSheetRef } from '@/utils/useSheetRef';
 import { formatDuration } from '@/utils/formatDuration';
@@ -34,6 +30,16 @@ import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { useExternalAlbumPreviews } from '@/hooks/albums/useExternalAlbumPreviews';
 import { useExternalAlbumStatus } from '@/hooks/useExternalAlbumStatus';
 import { externalSongToTrack } from '@/hooks/usePreviewPlayer';
+import {
+  DetailActionRow,
+  DetailCircleAction,
+  DetailHeader,
+  DetailHeaderIconButton,
+  DetailMetaDot,
+  DetailMetaRow,
+  DetailMetaText,
+  DetailPlayAction,
+} from '@/components/DetailHeader';
 
 type Props = {
   localAlbum: Album | null;
@@ -45,44 +51,18 @@ function isCountLikeAlbumText(value?: string | null): boolean {
 }
 
 const AlbumHeader: React.FC<Props> = ({ localAlbum, externalAlbum }) => {
-  const navigation = useNavigation<any>();
-  const { colors } = useTheme();
-
   const displayTitle = localAlbum?.title ?? externalAlbum?.title ?? '';
   const displayCover = localAlbum?.cover ?? externalAlbum?.cover ?? { kind: 'none' as const };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.headerRow}>
-        <TouchableOpacity testID="detail-back-button" onPress={() => navigation.goBack()} style={styles.headerButton}>
-          <ChevronLeft size={24} color={colors.secondary} />
-        </TouchableOpacity>
-
-        <View pointerEvents="none" style={styles.headerTitleWrapper}>
-          <Text style={[styles.headerTitle, { color: colors.secondary }]} numberOfLines={1}>
-            {displayTitle}
-          </Text>
-        </View>
-
-        {localAlbum ? <LocalOptionsButton album={localAlbum} /> : <View style={styles.headerButton} />}
-      </View>
-
-      <View style={styles.coverWrapper}>
-        <MediaImage cover={displayCover} size="detail" style={styles.coverImage} />
-      </View>
-
-      <View style={styles.titleInfo}>
-        <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={2}>
-          {displayTitle}
-        </Text>
-
-        {localAlbum ? <LocalMetaRow album={localAlbum} /> : <ExternalMetaRow album={externalAlbum!} />}
-      </View>
-
-      {!localAlbum && <ExternalServerStatusRow album={externalAlbum!} />}
-
-      {localAlbum ? <LocalActionRow album={localAlbum} /> : <ExternalActionRow album={externalAlbum!} />}
-    </View>
+    <DetailHeader
+      title={displayTitle}
+      cover={displayCover}
+      rightAction={localAlbum ? <LocalOptionsButton album={localAlbum} /> : undefined}
+      meta={localAlbum ? <LocalMetaRow album={localAlbum} /> : <ExternalMetaRow album={externalAlbum!} />}
+      status={!localAlbum ? <ExternalServerStatusRow album={externalAlbum!} /> : undefined}
+      actions={localAlbum ? <LocalActionRow album={localAlbum} /> : <ExternalActionRow album={externalAlbum!} />}
+    />
   );
 };
 
@@ -91,12 +71,11 @@ function LocalOptionsButton({ album }: { album: Album }) {
   const optionsSheetRef = useSheetRef();
   return (
     <>
-      <TouchableOpacity
+      <DetailHeaderIconButton
         onPress={() => optionsSheetRef.current?.present()}
-        style={styles.headerButton}
       >
         <Ellipsis size={24} color={colors.secondary} />
-      </TouchableOpacity>
+      </DetailHeaderIconButton>
       <AlbumOptions ref={optionsSheetRef} album={album} hideGoToAlbum />
     </>
   );
@@ -104,7 +83,6 @@ function LocalOptionsButton({ album }: { album: Album }) {
 
 function LocalMetaRow({ album }: { album: Album }) {
   const navigation = useNavigation<any>();
-  const { colors } = useTheme();
 
   const songs = useMemo(() => album.songs ?? [], [album.songs]);
   const totalDuration = useMemo(
@@ -131,40 +109,29 @@ function LocalMetaRow({ album }: { album: Album }) {
   }, [navigation]);
 
   return (
-    <View style={styles.metaRow}>
+    <DetailMetaRow>
       {metadataItems.map((item, index) => (
         <React.Fragment key={`${item.label}-${index}`}>
-          {index > 0 && (
-            <Text style={[styles.metaDot, { color: colors.subtext }]} numberOfLines={1}>
-              •
-            </Text>
-          )}
+          {index > 0 && <DetailMetaDot />}
           {item.type === 'artist' && album.artist ? (
             <TouchableOpacity onPress={() => navigation.push('artistView', { id: album.artist.id })}>
-              <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
-                {item.label}
-              </Text>
+              <DetailMetaText>{item.label}</DetailMetaText>
             </TouchableOpacity>
           ) : item.type === 'genre' ? (
             <TouchableOpacity onPress={() => handleGenrePress(item.label)}>
-              <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
-                {item.label}
-              </Text>
+              <DetailMetaText>{item.label}</DetailMetaText>
             </TouchableOpacity>
           ) : (
-            <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
-              {item.label}
-            </Text>
+            <DetailMetaText>{item.label}</DetailMetaText>
           )}
         </React.Fragment>
       ))}
-    </View>
+    </DetailMetaRow>
   );
 }
 
 function ExternalMetaRow({ album }: { album: ExternalAlbum }) {
   const { t } = useTranslation();
-  const { colors } = useTheme();
   const { navigateToArtist } = useMatchedNavigation();
 
   const songs = useMemo(() => album.songs ?? [], [album.songs]);
@@ -177,10 +144,10 @@ function ExternalMetaRow({ album }: { album: ExternalAlbum }) {
   }, [album.artist, songs.length, t]);
 
   return (
-    <View style={styles.metaRow}>
+    <DetailMetaRow>
       {metadataItems.map((item, index) => (
         <React.Fragment key={`${item}-${index}`}>
-          {index > 0 && <Text style={[styles.metaDot, { color: colors.subtext }]}>•</Text>}
+          {index > 0 && <DetailMetaDot />}
           {index === 0 && album.artist ? (
             <TouchableOpacity
               onPress={() =>
@@ -194,54 +161,45 @@ function ExternalMetaRow({ album }: { album: ExternalAlbum }) {
                 })
               }
             >
-              <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
-                {item}
-              </Text>
+              <DetailMetaText>{item}</DetailMetaText>
             </TouchableOpacity>
           ) : (
-            <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
-              {item}
-            </Text>
+            <DetailMetaText>{item}</DetailMetaText>
           )}
         </React.Fragment>
       ))}
-    </View>
+    </DetailMetaRow>
   );
 }
 
 function ExternalServerStatusRow({ album }: { album: ExternalAlbum }) {
   const { t } = useTranslation();
-  const { isDarkMode } = useTheme();
   const albumStatus = useExternalAlbumStatus(album);
 
   if (albumStatus.kind === 'none') return null;
 
-  const serverStatusBg = isDarkMode ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)';
-
+  if (albumStatus.kind === 'in_library') {
+    return (
+      <StatusBanner
+        icon={<Link size={14} color="#34C759" />}
+        text={t('externalAlbum.serverStatus.onServer')}
+        color="#34C759"
+        style={styles.serverStatusRow}
+      />
+    );
+  }
   return (
-    <View style={[styles.serverStatusRow, { backgroundColor: serverStatusBg }]}>
-      {albumStatus.kind === 'in_library' ? (
-        <>
-          <Link size={14} color="#34C759" />
-          <Text style={[styles.serverStatusText, { color: '#34C759' }]}>
-            {t('externalAlbum.serverStatus.onServer')}
-          </Text>
-        </>
-      ) : (
-        <>
-          <SpinningLoaderCircle size={14} color="#007AFF" />
-          <Text style={[styles.serverStatusText, { color: '#007AFF' }]}>
-            {t('externalAlbum.serverStatus.downloadingToServer', { progress: albumStatus.progress })}
-          </Text>
-        </>
-      )}
-    </View>
+    <StatusBanner
+      icon={<SpinningLoaderCircle size={14} color="#007AFF" />}
+      text={t('externalAlbum.serverStatus.downloadingToServer', { progress: albumStatus.progress })}
+      color="#007AFF"
+      style={styles.serverStatusRow}
+    />
   );
 }
 
 function LocalActionRow({ album }: { album: Album }) {
   const { colors } = useTheme();
-  const themeColor = useSelector(selectThemeColor);
   const { playSongInCollection } = usePlayingActions();
   const { downloadAlbumById, getCollectionDownloadState } = useDownload();
 
@@ -281,45 +239,35 @@ function LocalActionRow({ album }: { album: Album }) {
   }, [songs, album, playSongInCollection]);
 
   return (
-    <View style={styles.actionsRow}>
-      <View style={styles.actions}>
-        <TouchableOpacity
-          style={[styles.secondaryButton, { backgroundColor: colors.card }]}
-          onPress={handleShuffle}
-        >
-          <Shuffle size={18} color={colors.secondary} />
-        </TouchableOpacity>
+    <DetailActionRow>
+      <DetailCircleAction onPress={handleShuffle}>
+        <Shuffle size={18} color={colors.secondary} />
+      </DetailCircleAction>
 
-        <TouchableOpacity
-          style={[styles.playButton, { backgroundColor: themeColor }]}
-          onPress={handlePlay}
-        >
-          <Play size={20} color="#fff" fill="#fff" />
-        </TouchableOpacity>
+      <DetailPlayAction onPress={handlePlay}>
+        <Play size={20} color="#fff" fill="#fff" />
+      </DetailPlayAction>
 
-        <TouchableOpacity
-          style={[styles.secondaryButton, { backgroundColor: colors.card }]}
-          onPress={() => void toggleDownload()}
-          disabled={isAlbumDownloading}
-        >
-          {isAlbumDownloading ? (
-            <ActivityIndicator size="small" color={colors.secondary} />
-          ) : isAlbumDownloaded ? (
-            <Animated.View style={checkmarkStyle}>
-              <Check size={18} color={colors.secondary} />
-            </Animated.View>
-          ) : (
-            <Download size={18} color={colors.secondary} />
-          )}
-        </TouchableOpacity>
-      </View>
-    </View>
+      <DetailCircleAction
+        onPress={() => void toggleDownload()}
+        disabled={isAlbumDownloading}
+      >
+        {isAlbumDownloading ? (
+          <ActivityIndicator size="small" color={colors.secondary} />
+        ) : isAlbumDownloaded ? (
+          <Animated.View style={checkmarkStyle}>
+            <Check size={18} color={colors.secondary} />
+          </Animated.View>
+        ) : (
+          <Download size={18} color={colors.secondary} />
+        )}
+      </DetailCircleAction>
+    </DetailActionRow>
   );
 }
 
 function ExternalActionRow({ album }: { album: ExternalAlbum }) {
   const { colors } = useTheme();
-  const themeColor = useSelector(selectThemeColor);
   const canDownload = useAnyDownloaderConnected();
   const { playSongInCollection } = usePlayingActions();
   const albumStatus = useExternalAlbumStatus(album);
@@ -355,29 +303,23 @@ function ExternalActionRow({ album }: { album: ExternalAlbum }) {
 
   return (
     <>
-      <View style={styles.actionsRow}>
-        <View style={styles.actions}>
-          <TouchableOpacity
-            style={[styles.playButton, { backgroundColor: themeColor }]}
-            onPress={handleDownload}
-            disabled={!canDownload || albumStatus.kind !== 'none'}
-          >
-            <CloudDownload
-              size={20}
-              color={!canDownload || albumStatus.kind !== 'none' ? 'rgba(255,255,255,0.4)' : '#fff'}
-            />
-          </TouchableOpacity>
+      <DetailActionRow>
+        <DetailPlayAction
+          onPress={handleDownload}
+          disabled={!canDownload || albumStatus.kind !== 'none'}
+        >
+          <CloudDownload
+            size={20}
+            color={!canDownload || albumStatus.kind !== 'none' ? 'rgba(255,255,255,0.4)' : '#fff'}
+          />
+        </DetailPlayAction>
 
-          {previewSongs.length > 0 && (
-            <TouchableOpacity
-              style={[styles.secondaryButton, { backgroundColor: colors.card }]}
-              onPress={handlePlay}
-            >
-              <Play size={18} color={colors.secondary} fill={colors.secondary} />
-            </TouchableOpacity>
-          )}
-        </View>
-      </View>
+        {previewSongs.length > 0 && (
+          <DetailCircleAction onPress={handlePlay}>
+            <Play size={18} color={colors.secondary} fill={colors.secondary} />
+          </DetailCircleAction>
+        )}
+      </DetailActionRow>
 
       <DownloadSheet album={album} sheetRef={downloadSheetRef} />
     </>
@@ -387,108 +329,7 @@ function ExternalActionRow({ album }: { album: ExternalAlbum }) {
 export default AlbumHeader;
 
 const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 0,
-    alignItems: 'center',
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    width: '100%',
-  },
-  headerTitleWrapper: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    maxWidth: '60%',
-  },
-  headerButton: {
-    padding: 6,
-    width: 36,
-  },
-  coverWrapper: {
-    width: 280,
-    height: 280,
-    borderRadius: 16,
-    marginTop: 32,
-    marginBottom: 24,
-    overflow: 'hidden',
-  },
-  coverImage: {
-    width: '100%',
-    height: '100%',
-    borderRadius: 16,
-  },
-  titleInfo: {
-    width: '100%',
-    marginBottom: 20,
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '600',
-    marginBottom: 6,
-    textAlign: 'center',
-  },
-  subtext: {
-    fontSize: 14,
-  },
-  metaDot: {
-    fontSize: 14,
-    marginHorizontal: 6,
-  },
-  metaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    alignSelf: 'center',
-    flexWrap: 'nowrap',
-    maxWidth: '94%',
-    marginTop: 4,
-  },
-  actionsRow: {
-    width: '100%',
-    alignItems: 'center',
-    marginBottom: 12,
-  },
-  actions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-  },
-  secondaryButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  playButton: {
-    borderRadius: 22,
-    width: 112,
-    height: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   serverStatusRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 14,
-    paddingVertical: 6,
-    borderRadius: 12,
     marginBottom: 10,
-  },
-  serverStatusText: {
-    fontSize: 13,
-    fontWeight: '500',
   },
 });

--- a/src/screens/playing/components/OutputDeviceSheet.tsx
+++ b/src/screens/playing/components/OutputDeviceSheet.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { Airplay, Cast, Check, Plus, RotateCcw, Smartphone } from 'lucide-react-native';
+import IconActionButton from '@/components/IconActionButton';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
 import { useSelector } from 'react-redux';
 import { toast } from '@backpackapp-io/react-native-toast';
@@ -79,12 +80,13 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
         {/* Title */}
         <View style={styles.titleRow}>
           <Text style={[styles.title, { color: colors.secondary }]}>Connect</Text>
-          <TouchableOpacity onPress={scan} disabled={isScanning} style={styles.titleAction} activeOpacity={0.6}>
-            {isScanning
-              ? <SpinningLoaderCircle size={16} color={colors.subtext} />
-              : <RotateCcw size={16} color={colors.subtext} />
-            }
-          </TouchableOpacity>
+          <IconActionButton
+            icon={<RotateCcw size={16} color={colors.subtext} />}
+            onPress={scan}
+            loading={isScanning}
+            accessibilityLabel="Scan for devices"
+            size="compact"
+          />
         </View>
 
         {/* This device — always shown, highlighted when nothing is casting */}
@@ -207,9 +209,6 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: '600',
-  },
-  titleAction: {
-    padding: 4,
   },
   divider: {
     height: StyleSheet.hairlineWidth,

--- a/src/screens/playlist/components/Header/index.tsx
+++ b/src/screens/playlist/components/Header/index.tsx
@@ -1,28 +1,31 @@
 import React, { useCallback, useMemo } from 'react';
 import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
   ActivityIndicator,
 } from 'react-native';
-import { ChevronLeft, Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native';
-import { useNavigation } from '@react-navigation/native';
+import { Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native';
 
 import { Playlist } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import PlaylistOptions from '@/components/options/PlaylistOptions';
 
 import { usePlaying } from '@/contexts/PlayingContext';
 import { useDownload } from '@/contexts/DownloadContext';
-import { useSelector, useDispatch } from 'react-redux';
-import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { incrementPlay } from '@/utils/redux/slices/statsSlice';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { useSheetRef } from '@/utils/useSheetRef';
 import { formatDuration } from '@/utils/formatDuration';
+import {
+  DetailActionRow,
+  DetailCircleAction,
+  DetailHeader,
+  DetailHeaderIconButton,
+  DetailMetaDot,
+  DetailMetaRow,
+  DetailMetaText,
+  DetailPlayAction,
+} from '@/components/DetailHeader';
 
 type Props = {
   playlist: Playlist;
@@ -30,9 +33,7 @@ type Props = {
 
 const PlaylistHeader: React.FC<Props> = ({ playlist }) => {
   const { t } = useTranslation();
-  const navigation = useNavigation<any>();
   const { colors } = useTheme();
-  const themeColor = useSelector(selectThemeColor);
   const optionsSheetRef = useSheetRef();
 
   const dispatch = useDispatch();
@@ -80,179 +81,53 @@ const PlaylistHeader: React.FC<Props> = ({ playlist }) => {
   }, [songs, playlist, playSongInCollection, activeServer, dispatch]);
 
   return (
-    <View style={styles.container}>
-      <View style={styles.headerRow}>
-        <TouchableOpacity testID="detail-back-button" onPress={() => navigation.goBack()} style={styles.headerButton}>
-          <ChevronLeft size={24} color={colors.secondary} />
-        </TouchableOpacity>
+    <>
+      <DetailHeader
+        title={playlist.title}
+        cover={playlist.cover}
+        rightAction={
+          <DetailHeaderIconButton onPress={() => optionsSheetRef.current?.present()}>
+            <Ellipsis size={24} color={colors.secondary} />
+          </DetailHeaderIconButton>
+        }
+        meta={
+          <DetailMetaRow>
+            {metadataItems.map((item, index) => (
+              <React.Fragment key={`${item}-${index}`}>
+                {index > 0 && <DetailMetaDot />}
+                <DetailMetaText>{item}</DetailMetaText>
+              </React.Fragment>
+            ))}
+          </DetailMetaRow>
+        }
+        actions={
+          <DetailActionRow style={{ marginBottom: 18 }}>
+            <DetailCircleAction onPress={handleShuffle}>
+              <Shuffle size={18} color={colors.secondary} />
+            </DetailCircleAction>
 
-        <View pointerEvents="none" style={styles.headerTitleWrapper}>
-          <Text style={[styles.headerTitle, { color: colors.secondary }]} numberOfLines={1}>
-            {playlist.title}
-          </Text>
-        </View>
+            <DetailPlayAction onPress={handlePlay}>
+              <Play size={24} color="#fff" fill="#fff" />
+            </DetailPlayAction>
 
-        <TouchableOpacity
-          onPress={() => optionsSheetRef.current?.present()}
-          style={styles.headerButton}
-        >
-          <Ellipsis size={24} color={colors.secondary} />
-        </TouchableOpacity>
-      </View>
-
-      <PlaylistOptions ref={optionsSheetRef} playlist={playlist} hideGoToPlaylist />
-
-      <View style={styles.coverWrapper}>
-        <MediaImage cover={playlist.cover} size="detail" style={styles.coverImage} />
-      </View>
-
-      <View style={styles.titleInfo}>
-        <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={2}>
-          {playlist.title}
-        </Text>
-
-        <View style={styles.metaRow}>
-          {metadataItems.map((item, index) => (
-            <React.Fragment key={`${item}-${index}`}>
-              {index > 0 && (
-                <Text style={[styles.metaDot, { color: colors.subtext }]} numberOfLines={1}>
-                  •
-                </Text>
+            <DetailCircleAction
+              onPress={() => void toggleDownload()}
+              disabled={isPlaylistDownloading}
+            >
+              {isPlaylistDownloading ? (
+                <ActivityIndicator size="small" color={colors.secondary} />
+              ) : isPlaylistDownloaded ? (
+                <Check size={18} color={colors.secondary} />
+              ) : (
+                <Download size={18} color={colors.secondary} />
               )}
-              <Text style={[styles.subtext, { color: colors.subtext }]} numberOfLines={1}>
-                {item}
-              </Text>
-            </React.Fragment>
-          ))}
-        </View>
-      </View>
-
-      <View style={styles.actionsRow}>
-        <View style={styles.actions}>
-          <TouchableOpacity
-            style={[styles.secondaryButton, { backgroundColor: colors.card }]}
-            onPress={handleShuffle}
-          >
-            <Shuffle size={18} color={colors.secondary} />
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.playButton, { backgroundColor: themeColor }]}
-            onPress={handlePlay}
-          >
-            <Play size={24} color="#fff" fill="#fff" />
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.secondaryButton, { backgroundColor: colors.card }]}
-            onPress={() => void toggleDownload()}
-            disabled={isPlaylistDownloading}
-          >
-            {isPlaylistDownloading ? (
-              <ActivityIndicator size="small" color={colors.secondary} />
-            ) : isPlaylistDownloaded ? (
-              <Check size={18} color={colors.secondary} />
-            ) : (
-              <Download size={18} color={colors.secondary} />
-            )}
-          </TouchableOpacity>
-        </View>
-      </View>
-    </View>
+            </DetailCircleAction>
+          </DetailActionRow>
+        }
+      />
+      <PlaylistOptions ref={optionsSheetRef} playlist={playlist} hideGoToPlaylist />
+    </>
   );
 };
 
 export default PlaylistHeader;
-
-const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 0,
-    alignItems: 'center',
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    width: '100%',
-  },
-  headerTitleWrapper: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  headerTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    maxWidth: '60%',
-  },
-  headerButton: {
-    padding: 6,
-  },
-  coverWrapper: {
-    width: 280,
-    height: 280,
-    borderRadius: 16,
-    marginTop: 32,
-    marginBottom: 24,
-    overflow: 'hidden',
-  },
-  coverImage: {
-    width: '100%',
-    height: '100%',
-    borderRadius: 16,
-  },
-  titleInfo: {
-    width: '100%',
-    marginBottom: 20,
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '600',
-    marginBottom: 6,
-    textAlign: 'center',
-  },
-  subtext: {
-    fontSize: 14,
-  },
-  metaDot: {
-    fontSize: 14,
-    marginHorizontal: 6,
-  },
-  metaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    alignSelf: 'center',
-    flexWrap: 'nowrap',
-    maxWidth: '94%',
-    marginTop: 4,
-  },
-  actionsRow: {
-    width: '100%',
-    alignItems: 'center',
-    marginBottom: 18,
-  },
-  actions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-  },
-  secondaryButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  playButton: {
-    borderRadius: 22,
-    width: 112,
-    height: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});

--- a/src/screens/playlist/components/RecommendedSection/index.tsx
+++ b/src/screens/playlist/components/RecommendedSection/index.tsx
@@ -13,7 +13,9 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@backpackapp-io/react-native-toast';
 
 import { useTheme } from '@/hooks/useTheme';
-import { MediaImage } from '@/components/MediaImage';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
+import SectionHeader from '@/components/SectionHeader';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { usePreviewPlayer } from '@/hooks/usePreviewPlayer';
 import { selectThemeColor, selectShowSourceHeaders, selectDeezerDiscoveryEnabled } from '@/utils/redux/selectors/settingsSelectors';
@@ -33,7 +35,6 @@ import type { Playlist, SongBase, ExternalAlbumBase, ExternalSong } from '@/type
 
 const LOCAL_COUNT = 8;
 const EXTERNAL_COUNT = 8;
-const COVER_SIZE = 44;
 
 function shuffle<T>(arr: T[]): T[] {
   return [...arr].sort(() => Math.random() - 0.5);
@@ -117,23 +118,6 @@ async function fetchExternalRecs(artistNames: string[]): Promise<ExternalSong[]>
   }
 }
 
-// ── Shared section header ──────────────────────────────────────────────────────
-
-type SectionHeaderProps = {
-  title: string;
-  badge?: React.ReactNode;
-};
-
-const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge }) => {
-  const { colors } = useTheme();
-  return (
-    <View style={styles.sectionTitleRow}>
-      {badge}
-      <Text style={[styles.sectionTitle, { color: colors.secondary }]}>{title}</Text>
-    </View>
-  );
-};
-
 // ── Local song row ─────────────────────────────────────────────────────────────
 
 type LocalRowProps = {
@@ -175,23 +159,21 @@ const LocalRow: React.FC<LocalRowProps> = ({ song, playlistId }) => {
   }, [adding, added, addToPlaylist, playlistId, song.id, t]);
 
   return (
-    <TouchableOpacity style={styles.row} onPress={() => void handlePress()} activeOpacity={0.7}>
-      <MediaImage cover={song.cover} size="thumb" style={styles.cover} />
-      <View style={styles.rowText}>
-        <Text style={[styles.rowTitle, { color: colors.secondary }]} numberOfLines={1}>
-          {song.title}
-        </Text>
-        <Text style={[styles.rowSub, { color: colors.subtext }]} numberOfLines={1}>
-          {song.artist}{song.duration ? ` · ${formatSongDuration(song.duration)}` : ''}
-        </Text>
-      </View>
-      <TouchableOpacity onPress={() => void handleAdd()} hitSlop={10} style={styles.actionBtn} disabled={adding || added}>
-        {added
-          ? <CheckCircle size={22} color={colors.placeholder} />
-          : <CirclePlus size={22} color={(adding || added) ? colors.placeholder : colors.subtext} />
-        }
-      </TouchableOpacity>
-    </TouchableOpacity>
+    <MediaListRow
+      title={song.title}
+      subtitle={`${song.artist}${song.duration ? ` · ${formatSongDuration(song.duration)}` : ''}`}
+      cover={song.cover}
+      onPress={() => void handlePress()}
+      variant="compact"
+      trailing={
+        <TouchableOpacity onPress={() => void handleAdd()} hitSlop={10} style={styles.actionBtn} disabled={adding || added}>
+          {added
+            ? <CheckCircle size={22} color={colors.placeholder} />
+            : <CirclePlus size={22} color={(adding || added) ? colors.placeholder : colors.subtext} />
+          }
+        </TouchableOpacity>
+      }
+    />
   );
 };
 
@@ -209,33 +191,27 @@ const ExternalRow: React.FC<ExternalRowProps> = ({ song, hasDownloader, onDownlo
   const hasPreview = !!song.previewUrl;
 
   return (
-    <TouchableOpacity
-      style={styles.row}
+    <MediaListRow
+      title={song.title}
+      subtitle={`${song.artist}${song.duration ? ` · ${formatSongDuration(song.duration)}` : ''}`}
+      cover={song.cover}
       onPress={() => song.previewUrl && void toggle(song, song.previewUrl)}
       disabled={!hasPreview}
-      activeOpacity={hasPreview ? 0.7 : 1}
-    >
-      <MediaImage cover={song.cover} size="thumb" style={styles.cover} />
-      <View style={styles.rowText}>
-        <Text style={[styles.rowTitle, { color: colors.secondary }]} numberOfLines={1}>
-          {song.title}
-        </Text>
-        <Text style={[styles.rowSub, { color: colors.subtext }]} numberOfLines={1}>
-          {song.artist}{song.duration ? ` · ${formatSongDuration(song.duration)}` : ''}
-        </Text>
-      </View>
-      <TouchableOpacity
-        onPress={() => hasDownloader && onDownload(song)}
-        disabled={!hasDownloader}
-        hitSlop={10}
-        style={styles.actionBtn}
-      >
-        <CloudDownload
-          size={22}
-          color={hasDownloader ? colors.subtext : colors.muted}
-        />
-      </TouchableOpacity>
-    </TouchableOpacity>
+      variant="compact"
+      trailing={
+        <TouchableOpacity
+          onPress={() => hasDownloader && onDownload(song)}
+          disabled={!hasDownloader}
+          hitSlop={10}
+          style={styles.actionBtn}
+        >
+          <CloudDownload
+            size={22}
+            color={hasDownloader ? colors.subtext : colors.muted}
+          />
+        </TouchableOpacity>
+      }
+    />
   );
 };
 
@@ -283,22 +259,21 @@ export const LocalRecommendedSection: React.FC<LocalRecommendedSectionProps> = (
 
   return (
     <View style={styles.section}>
-      <SectionHeader title={t('playlist.recommended.local')} />
+      <SectionHeader
+        title={t('playlist.recommended.local')}
+        action={
+          <IconActionButton
+            icon={<RefreshCw size={17} color={colors.subtext} />}
+            onPress={onRefresh}
+            accessibilityLabel={t('playlist.recommended.refresh')}
+            size="compact"
+          />
+        }
+      />
 
       {localSongs.map(song => (
         <LocalRow key={song.id} song={song} playlistId={playlist.id} />
       ))}
-
-      <TouchableOpacity
-        style={[styles.refreshBtn, { borderColor: colors.border }]}
-        onPress={onRefresh}
-        activeOpacity={0.7}
-      >
-        <RefreshCw size={16} color={colors.subtext} />
-        <Text style={[styles.refreshText, { color: colors.subtext }]}>
-          {t('playlist.recommended.refresh')}
-        </Text>
-      </TouchableOpacity>
     </View>
   );
 };
@@ -383,6 +358,15 @@ export const DeezerRecommendedSection: React.FC<DeezerRecommendedSectionProps> =
             </View>
           ) : undefined
         }
+        action={
+          <IconActionButton
+            icon={<RefreshCw size={17} color={colors.subtext} />}
+            onPress={onRefreshExternal}
+            loading={externalQuery.isFetching}
+            accessibilityLabel={t('playlist.recommended.refresh')}
+            size="compact"
+          />
+        }
       />
 
       {externalQuery.isLoading ? (
@@ -401,22 +385,6 @@ export const DeezerRecommendedSection: React.FC<DeezerRecommendedSectionProps> =
           />
         ))
       )}
-
-      <TouchableOpacity
-        style={[styles.refreshBtn, { borderColor: colors.border }]}
-        onPress={onRefreshExternal}
-        activeOpacity={0.7}
-        disabled={externalQuery.isFetching}
-      >
-        <RefreshCw
-          size={16}
-          color={colors.subtext}
-          style={{ opacity: externalQuery.isFetching ? 0.3 : 1 }}
-        />
-        <Text style={[styles.refreshText, { color: colors.subtext, opacity: externalQuery.isFetching ? 0.3 : 1 }]}>
-          {t('playlist.recommended.refresh')}
-        </Text>
-      </TouchableOpacity>
 
       {albumForDownload && (
         <DownloadSheet
@@ -485,13 +453,6 @@ const styles = StyleSheet.create({
   section: {
     paddingTop: 24,
   },
-  sectionTitleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    marginBottom: 12,
-    gap: 8,
-  },
   sourceBadge: {
     width: 22,
     height: 22,
@@ -507,35 +468,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#fff',
   },
-  sectionTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-  },
-  cover: {
-    width: COVER_SIZE,
-    height: COVER_SIZE,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  rowText: {
-    flex: 1,
-    minWidth: 0,
-    marginRight: 6,
-  },
-  rowTitle: {
-    fontSize: 15,
-    fontWeight: '400',
-  },
-  rowSub: {
-    fontSize: 13,
-    marginTop: 1,
-  },
   actionBtn: { padding: 4 },
   loader: { marginVertical: 24 },
   emptyText: {
@@ -543,20 +475,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     paddingHorizontal: 16,
     paddingVertical: 20,
-  },
-  refreshBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-    marginHorizontal: 16,
-    marginTop: 8,
-    paddingVertical: 12,
-    borderWidth: 1,
-    borderRadius: 10,
-  },
-  refreshText: {
-    fontSize: 14,
-    fontWeight: '500',
   },
 });

--- a/src/screens/settings/library/components/Stats.tsx
+++ b/src/screens/settings/library/components/Stats.tsx
@@ -8,6 +8,7 @@ import { selectSyncOnAppStart } from '@/utils/redux/selectors/settingsSelectors'
 import { setSyncOnAppStart } from '@/utils/redux/slices/settingsSlice';
 import { useTheme } from '@/hooks/useTheme';
 import { useSync } from '@/hooks/useSync';
+import IconActionButton from '@/components/IconActionButton';
 import SettingsCard from '../../components/SettingsCard';
 import SettingsInfoRow from '../../components/SettingsInfoRow';
 import SettingsToggleGroup from '../../components/SettingsToggleGroup';
@@ -62,13 +63,20 @@ const Stats: React.FC = () => {
           value={formatLastSynced(lastSyncedAt, t, now)}
           stacked
           right={
-            <Animated.View style={spinStyle}>
-              <RefreshCw
-                size={18}
-                color={isSyncing ? colors.themeColor : colors.secondary}
-                onPress={() => !isSyncing && sync(true)}
-              />
-            </Animated.View>
+            <IconActionButton
+              icon={
+                <Animated.View style={spinStyle}>
+                  <RefreshCw
+                    size={18}
+                    color={isSyncing ? colors.themeColor : colors.secondary}
+                  />
+                </Animated.View>
+              }
+              onPress={() => sync(true)}
+              disabled={isSyncing}
+              accessibilityLabel={t('settings.library.stats.lastSynced')}
+              size="compact"
+            />
           }
         />
       </SettingsCard>


### PR DESCRIPTION
## Summary
- Add shared design tokens plus reusable SectionHeader, IconActionButton, DetailHeader, and MediaListRow primitives
- Move playlist refresh controls, album/playlist detail headers, and album/artist/playlist list rows onto shared components
- Use shared icon actions for library sync and output-device scanning

## Validation
- npx tsc --noEmit
- npm run lint