### PR TITLE
Consolidate media rows and detail actions

### DIFF
--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -20,6 +20,7 @@ type Props = {
   disabled?: boolean;
   trailing?: React.ReactNode;
   roundedCover?: boolean;
+  showCover?: boolean;
   variant?: 'default' | 'compact';
   contentStyle?: StyleProp<ViewStyle>;
   rowStyle?: StyleProp<ViewStyle>;
@@ -34,6 +35,7 @@ export default function MediaListRow({
   disabled,
   trailing,
   roundedCover,
+  showCover = true,
   variant = 'default',
   contentStyle,
   rowStyle,
@@ -51,17 +53,19 @@ export default function MediaListRow({
           disabled={disabled || !onPress}
           activeOpacity={disabled ? 1 : 0.7}
         >
-          <MediaImage
-            cover={cover}
-            size={isCompact ? 'thumb' : 'grid'}
-            style={[
-              styles.cover,
-              isCompact && styles.compactCover,
-              roundedCover && (isCompact ? styles.compactCoverRounded : styles.coverRounded),
-            ]}
-          />
+          {showCover && (
+            <MediaImage
+              cover={cover}
+              size={isCompact ? 'thumb' : 'grid'}
+              style={[
+                styles.cover,
+                isCompact && styles.compactCover,
+                roundedCover && (isCompact ? styles.compactCoverRounded : styles.coverRounded),
+              ]}
+            />
+          )}
 
-          <View style={styles.textContainer}>
+          <View style={[styles.textContainer, !showCover && styles.textContainerNoCover]}>
             <Text
               numberOfLines={1}
               style={[isCompact ? styles.compactTitle : styles.title, { color: colors.secondary }]}
@@ -122,6 +126,9 @@ const styles = StyleSheet.create({
   textContainer: {
     flex: 1,
     marginLeft: spacing.rowGap,
+  },
+  textContainerNoCover: {
+    marginLeft: 0,
   },
   title: typography.rowTitle,
   compactTitle: typography.compactRowTitle,

--- a/src/components/rows/SongRow/index.tsx
+++ b/src/components/rows/SongRow/index.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback, useEffect, useState } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
@@ -16,7 +15,7 @@ import { Song } from '@/types';
 import SongOptions from '@/components/options/SongOptions';
 import PlaylistList from '@/components/PlaylistList';
 import { usePlayingActions } from '@/contexts/PlayingContext';
-import { MediaImage } from '@/components/MediaImage';
+import MediaListRow from '@/components/MediaListRow';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { useDownloadState } from '@/contexts/DownloadContext';
@@ -87,52 +86,30 @@ const SongRow: React.FC<Props> = ({
 
   return (
     <>
-      <View style={[styles.row, isAlbumCompact && styles.rowAlbumCompact]}>
-        <TouchableOpacity
-          style={styles.songInfo}
-          onPress={handlePress}
-          disabled={!onPress && !collection}
-        >
-          {!isAlbumCompact && (
-            <View style={styles.defaultLeading}>
-              <MediaImage
-                cover={song.cover}
-                size="thumb"
-                style={styles.cover}
-              />
-            </View>
-          )}
-
-          <View style={styles.textContainer}>
-            <Text
-              style={[styles.title, { color: colors.secondary }]}
-              numberOfLines={1}
-            >
-              {song.title}
-            </Text>
-
-            <Text
-              style={[styles.subtitle, { color: colors.subtext }]}
-              numberOfLines={1}
-            >
-              {song.artist || t('songOptions.unknownArtist')}
-              {!isAlbumCompact && ` • ${formatSongDuration(song.duration)}`}
-            </Text>
+      <MediaListRow
+        title={song.title}
+        subtitle={`${song.artist || t('songOptions.unknownArtist')}${!isAlbumCompact ? ` • ${formatSongDuration(song.duration)}` : ''}`}
+        cover={song.cover}
+        onPress={handlePress}
+        disabled={!onPress && !collection}
+        showCover={!isAlbumCompact}
+        variant="compact"
+        contentStyle={styles.mediaContent}
+        rowStyle={isAlbumCompact ? styles.mediaRowAlbumCompact : undefined}
+        trailing={
+          <View style={styles.rowRight}>
+            <Animated.View style={heartStyle}>
+              <Heart size={15} color="#ff4d67" fill="#ff4d67" />
+            </Animated.View>
+            {downloaded && (isAlbumCompact || showDownloadedDot) && (
+              <ArrowDownCircle size={16} color={colors.subtext} />
+            )}
+            <TouchableOpacity onPress={openOptions} hitSlop={10}>
+              <Ellipsis size={18} color={colors.secondary} />
+            </TouchableOpacity>
           </View>
-        </TouchableOpacity>
-
-        <View style={styles.rowRight}>
-          <Animated.View style={heartStyle}>
-            <Heart size={15} color="#ff4d67" fill="#ff4d67" />
-          </Animated.View>
-          {downloaded && (isAlbumCompact || showDownloadedDot) && (
-            <ArrowDownCircle size={16} color={colors.subtext} />
-          )}
-          <TouchableOpacity onPress={openOptions} hitSlop={10}>
-            <Ellipsis size={18} color={colors.secondary} />
-          </TouchableOpacity>
-        </View>
-      </View>
+        }
+      />
 
       <SongOptions
         ref={optionsRef}
@@ -150,51 +127,16 @@ const SongRow: React.FC<Props> = ({
 };
 
 const styles = StyleSheet.create({
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 16,
+  mediaContent: {
+    marginRight: 12,
   },
-  rowAlbumCompact: {
+  mediaRowAlbumCompact: {
     paddingVertical: 13,
-  },
-  songInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-    marginRight: 12,
-  },
-  cover: {
-    width: 44,
-    height: 44,
-    borderRadius: 6,
-    marginRight: 0,
-  },
-  defaultLeading: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginRight: 12,
-  },
-  textContainer: {
-    flex: 1,
   },
   rowRight: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-  },
-  trackNumber: {
-    fontSize: 13,
-    minWidth: 16,
-  },
-  title: {
-    fontSize: 15,
-    fontWeight: '500',
-  },
-  subtitle: {
-    fontSize: 13,
-    marginTop: 2,
   },
 });
 

--- a/src/screens/artist/components/Header/index.tsx
+++ b/src/screens/artist/components/Header/index.tsx
@@ -19,7 +19,6 @@ import ArtistOptions from '@/components/options/ArtistOptions';
 import { Artist, ExternalArtist, Song } from '@/types';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { toast } from '@backpackapp-io/react-native-toast';
-import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors';
 import { useArtistAlbums } from '@/hooks/artists';
 import { useTracks } from '@/hooks/tracks';
 import { buildCover } from '@/utils/builders/buildCover';
@@ -29,6 +28,7 @@ import { useSheetRef } from '@/utils/useSheetRef';
 import { useApi } from '@/api';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { fetchAlbumDetailsSettled } from '@/hooks/albums';
+import { DetailActionRow, DetailCircleAction, DetailPlayAction } from '@/components/DetailHeader';
 
 type Props = {
   localArtist: Artist | null;
@@ -213,7 +213,6 @@ function LocalActionRow({ artist }: { artist: Artist }) {
   const { isDarkMode, colors } = useTheme();
   const queryClient = useQueryClient();
   const api = useApi();
-  const themeColor = useSelector(selectThemeColor);
   const activeServer = useSelector(selectActiveServer);
 
   const { playSongInCollection } = usePlaying();
@@ -296,35 +295,34 @@ function LocalActionRow({ artist }: { artist: Artist }) {
   }, [isDownloadingAll, isArtistDownloading, isArtistFullyDownloaded, artistAlbums, downloadAlbumById]);
 
   return (
-    <View style={styles.buttonRow}>
-      <TouchableOpacity
+    <DetailActionRow style={styles.buttonRow}>
+      <DetailCircleAction
         onPress={() => void playArtist(true)}
         disabled={songsLoading}
-        style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+        style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
       >
         {songsLoading ? (
           <ActivityIndicator size="small" color={colors.secondary} />
         ) : (
           <Shuffle size={18} color={colors.secondary} />
         )}
-      </TouchableOpacity>
+      </DetailCircleAction>
 
-      <TouchableOpacity
+      <DetailPlayAction
         onPress={() => void playArtist(false)}
         disabled={songsLoading}
-        style={[styles.playButton, { backgroundColor: themeColor }]}
       >
         {songsLoading ? (
           <ActivityIndicator size="small" color="#fff" />
         ) : (
           <Play size={24} color="#fff" fill="#fff" />
         )}
-      </TouchableOpacity>
+      </DetailPlayAction>
 
-      <TouchableOpacity
+      <DetailCircleAction
         onPress={() => void handleDownloadAll()}
         disabled={isDownloadingAll || isArtistDownloading}
-        style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+        style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
       >
         {isDownloadingAll || isArtistDownloading ? (
           <ActivityIndicator size="small" color={colors.secondary} />
@@ -333,8 +331,8 @@ function LocalActionRow({ artist }: { artist: Artist }) {
         ) : (
           <Download size={18} color={colors.secondary} />
         )}
-      </TouchableOpacity>
-    </View>
+      </DetailCircleAction>
+    </DetailActionRow>
   );
 }
 
@@ -409,28 +407,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   buttonRow: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 10,
     marginBottom: 24,
   },
   secondaryButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
     backgroundColor: 'rgba(0,0,0,0.05)',
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   secondaryButtonDark: {
     backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  playButton: {
-    borderRadius: 22,
-    width: 112,
-    height: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });

--- a/src/screens/genre/components/Header/index.tsx
+++ b/src/screens/genre/components/Header/index.tsx
@@ -24,8 +24,8 @@ import { useTheme } from '@/hooks/useTheme'
 import { useTracks } from '@/hooks/tracks'
 import { usePlaying } from '@/contexts/PlayingContext'
 import { useDownload } from '@/contexts/DownloadContext'
-import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors'
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors'
+import { DetailActionRow, DetailCircleAction, DetailPlayAction } from '@/components/DetailHeader'
 
 type Props = {
   genre: string
@@ -37,7 +37,6 @@ const GenreHeader: React.FC<Props> = ({ genre, albums }) => {
   const queryClient = useQueryClient()
   const api = useApi()
   const { isDarkMode, colors } = useTheme()
-  const themeColor = useSelector(selectThemeColor)
   const activeServer = useSelector(selectActiveServer)
   const { playSongInCollection } = usePlaying()
   const { downloadAlbumById, getCollectionDownloadState } = useDownload()
@@ -175,35 +174,34 @@ const GenreHeader: React.FC<Props> = ({ genre, albums }) => {
         </Text>
       </View>
 
-      <View style={styles.buttonRow}>
-        <TouchableOpacity
+      <DetailActionRow style={styles.buttonRow}>
+        <DetailCircleAction
           onPress={() => { void play(true) }}
           disabled={songsLoading}
-          style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+          style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
         >
           {songsLoading ? (
             <ActivityIndicator size="small" color={colors.secondary} />
           ) : (
             <Shuffle size={18} color={colors.secondary} />
           )}
-        </TouchableOpacity>
+        </DetailCircleAction>
 
-        <TouchableOpacity
+        <DetailPlayAction
           onPress={() => { void play(false) }}
           disabled={songsLoading}
-          style={[styles.playButton, { backgroundColor: themeColor }]}
         >
           {songsLoading ? (
             <ActivityIndicator size="small" color="#fff" />
           ) : (
             <Play size={24} color="#fff" fill="#fff" />
           )}
-        </TouchableOpacity>
+        </DetailPlayAction>
 
-        <TouchableOpacity
+        <DetailCircleAction
           onPress={() => { void handleDownloadAll() }}
           disabled={isDownloadingAll || isDownloading}
-          style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+          style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
         >
           {isDownloadingAll || isDownloading ? (
             <ActivityIndicator size="small" color={colors.secondary} />
@@ -212,8 +210,8 @@ const GenreHeader: React.FC<Props> = ({ genre, albums }) => {
           ) : (
             <Download size={18} color={colors.secondary} />
           )}
-        </TouchableOpacity>
-      </View>
+        </DetailCircleAction>
+      </DetailActionRow>
     </>
   )
 }
@@ -259,28 +257,12 @@ const styles = StyleSheet.create({
     marginTop: 6,
   },
   buttonRow: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 10,
     marginBottom: 24,
   },
   secondaryButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
     backgroundColor: 'rgba(0,0,0,0.05)',
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   secondaryButtonDark: {
     backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  playButton: {
-    borderRadius: 22,
-    width: 112,
-    height: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 })

--- a/src/screens/home/components/QuickPicksSection/index.tsx
+++ b/src/screens/home/components/QuickPicksSection/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
-  TouchableOpacity,
   ScrollView,
   StyleSheet,
   useWindowDimensions,
@@ -14,7 +13,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/hooks/useTheme';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { usePlayableSongResolver } from '@/hooks/songs';
-import { MediaImage } from '@/components/MediaImage';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import SongOptions from '@/components/options/SongOptions';
 import PlaylistList from '@/components/PlaylistList';
 import { useSheetRef } from '@/utils/useSheetRef';
@@ -32,7 +32,6 @@ const TOTAL_PAGES = 3;
 const TOTAL_PICKS = PAGE_SIZE * TOTAL_PAGES;
 const CANDIDATE_POOL = TOTAL_PICKS * 2; // draw from a wider pool on refresh
 const H_PADDING = 12;
-const IMG_SIZE = 44;
 const DECAY_MS = 7 * 24 * 60 * 60 * 1000;
 const PEEK = 28; // pixels of the next page visible at the right edge
 
@@ -153,31 +152,24 @@ export default function QuickPicksSection({ refreshKey = 0 }: Props) {
             {pages.map((page, pageIdx) => (
               <View key={pageIdx} style={[styles.page, { width: screenWidth - PEEK }]}>
                 {page.map(song => (
-                  <TouchableOpacity
+                  <MediaListRow
                     key={song.id}
-                    style={styles.row}
+                    title={song.title}
+                    subtitle={song.artist}
+                    cover={song.cover}
                     onPress={() => { void handlePress(song); }}
-                    activeOpacity={0.7}
-                  >
-                    <MediaImage cover={song.cover} size="thumb" style={styles.art} />
-                    <View style={styles.info}>
-                      <Text style={[styles.trackTitle, { color: colors.secondary }]} numberOfLines={1}>
-                        {song.title}
-                      </Text>
-                      <Text style={[styles.trackArtist, { color: colors.subtext }]} numberOfLines={1}>
-                        {song.artist}
-                      </Text>
-                    </View>
-                    <TouchableOpacity
-                      onPress={() => { void handleOptions(song); }}
-                      hitSlop={10}
-                    >
-                      <Ellipsis
-                        size={18}
-                        color={colors.secondary}
+                    variant="compact"
+                    style={styles.rowWrapper}
+                    rowStyle={styles.row}
+                    trailing={
+                      <IconActionButton
+                        icon={<Ellipsis size={18} color={colors.secondary} />}
+                        onPress={() => { void handleOptions(song); }}
+                        accessibilityLabel={`${song.title} options`}
+                        size="compact"
                       />
-                    </TouchableOpacity>
-                  </TouchableOpacity>
+                    }
+                  />
                 ))}
               </View>
             ))}
@@ -216,27 +208,11 @@ const styles = StyleSheet.create({
   page: {
     gap: 2,
   },
+  rowWrapper: {
+    paddingHorizontal: 0,
+  },
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
     paddingHorizontal: H_PADDING,
     paddingVertical: 6,
-    gap: 12,
-  },
-  art: {
-    width: IMG_SIZE,
-    height: IMG_SIZE,
-    borderRadius: 4,
-  },
-  info: {
-    flex: 1,
-    gap: 2,
-  },
-  trackTitle: {
-    fontSize: 15,
-    fontWeight: '500',
-  },
-  trackArtist: {
-    fontSize: 13,
   },
 });

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -21,7 +21,8 @@ import LoadingAlbumRow from '@/components/rows/AlbumRow/Loading';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { usePlaying } from '@/contexts/PlayingContext';
-import { MediaImage } from '@/components/MediaImage';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import SongOptions from '@/components/options/SongOptions';
 import PlaylistList from '@/components/PlaylistList';
 import { Song } from '@/types';
@@ -131,30 +132,20 @@ const Search = () => {
   const renderResult = (result: SearchResult) => {
     if (result.type === 'song') {
       return (
-        <View style={styles.songWrapper}>
-          <View style={styles.songRow}>
-            <TouchableOpacity
-              accessibilityLabel={`Search result song ${result.title}`}
-              accessibilityRole="button"
-              testID="search-song-result"
-              style={styles.songInfo}
-              onPress={() => { void handleSongPress(result); }}
-            >
-              <MediaImage cover={result.cover} size="thumb" style={styles.songCover} />
-              <View style={styles.songText}>
-                <Text numberOfLines={1} style={[styles.songTitle, { color: colors.secondary }]}>
-                  {result.title}
-                </Text>
-                <Text numberOfLines={1} style={[styles.songSubtitle, { color: colors.subtext }]}>
-                  {result.subtext}
-                </Text>
-              </View>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.songOptionsButton} onPress={() => { void handleSongOptions(result); }}>
-              <Ellipsis size={24} color={colors.secondary} />
-            </TouchableOpacity>
-          </View>
-        </View>
+        <MediaListRow
+          title={result.title}
+          subtitle={result.subtext}
+          cover={result.cover}
+          onPress={() => { void handleSongPress(result); }}
+          trailing={
+            <IconActionButton
+              icon={<Ellipsis size={24} color={colors.secondary} />}
+              onPress={() => { void handleSongOptions(result); }}
+              accessibilityLabel={`Search result song ${result.title} options`}
+              size="compact"
+            />
+          }
+        />
       );
     }
 
@@ -386,38 +377,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 24,
     fontSize: 16,
-  },
-  songWrapper: {
-    paddingHorizontal: 16,
-  },
-  songRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  songInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  songCover: {
-    width: 64,
-    height: 64,
-    borderRadius: 6,
-  },
-  songText: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  songTitle: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  songSubtitle: {
-    fontSize: 14,
-    marginTop: 2,
-  },
-  songOptionsButton: {
-    padding: 8,
   },
 });


### PR DESCRIPTION
## Summary
- Extend MediaListRow for compact rows without artwork
- Move SongRow, search song results, and quick picks onto MediaListRow
- Reuse detail action primitives for artist and genre play/shuffle/download actions

## Validation
- npx tsc --noEmit
- npm run lint