### PR TITLE
Server-unreachable handling: reachability circuit breaker, hydrated album fallback, status banner

### DIFF
--- a/src/api/mediaBrowser/tracks/getTracks.ts
+++ b/src/api/mediaBrowser/tracks/getTracks.ts
@@ -15,6 +15,8 @@ function normalizeTrack(item: MediaBrowserItem, client: MediaBrowserClient): Son
     albumId: item.AlbumId ?? "",
     cover,
     duration: String(Math.floor((item.RunTimeTicks ?? 0) / 10_000_000)),
+    disc: item.ParentIndexNumber ?? undefined,
+    trackNumber: item.IndexNumber ?? undefined,
     year: item.ProductionYear ?? undefined,
     dateAdded: item.DateCreated ?? undefined,
     serverPlayCount: item.UserData?.PlayCount ?? undefined,
@@ -30,7 +32,7 @@ export async function getTracks(client: MediaBrowserClient): Promise<SongBase[]>
     `?IncludeItemTypes=Audio` +
     `&Recursive=true` +
     `&SortBy=SortName` +
-    `&Fields=RunTimeTicks,ArtistItems,AlbumId,ProductionYear,DateCreated,UserData` +
+    `&Fields=RunTimeTicks,ArtistItems,AlbumId,ProductionYear,DateCreated,UserData,IndexNumber,ParentIndexNumber` +
     (client.parentId ? `&ParentId=${encodeURIComponent(client.parentId)}` : "");
 
   const raw = await client.request<MediaBrowserItemsResponse>(path);

--- a/src/api/navidrome/tracks/getTracks.ts
+++ b/src/api/navidrome/tracks/getTracks.ts
@@ -16,6 +16,8 @@ function mapToSongBase(song: SubsonicSong & { id: string }): SongBase {
       : { kind: 'none' as const },
     duration: String(song.duration ?? 0),
     albumId: song.albumId ?? '',
+    disc: song.discNumber ?? undefined,
+    trackNumber: song.track ?? undefined,
     year: song.year ?? undefined,
     dateAdded: song.created,
     serverPlayCount: song.playCount ?? undefined,

--- a/src/app/(home)/_layout.tsx
+++ b/src/app/(home)/_layout.tsx
@@ -14,6 +14,7 @@ import { selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
 import { clearLibrary } from '@/utils/redux/slices/librarySlice';
 import PlayingBar from '@/screens/playing/playingBar/PlayingBar';
 import { ExternalResolutionProvider } from '@/features/sources/ExternalResolutionProvider';
+import { ServerReachabilityWatcher } from '@/features/connectivity/ServerReachabilityWatcher';
 import { AccountSheetProvider } from '@/contexts/AccountSheetContext';
 
 function TabIcon({ onPress, active, accessibilityLabel, testID, activeColor, inactiveColor, activeIndicatorBg, children }: {
@@ -104,6 +105,7 @@ export default function HomeLayout() {
     return (
         <ExternalResolutionProvider>
         <AccountSheetProvider>
+        <ServerReachabilityWatcher />
         <View style={{ flex: 1 }}>
             <Stack>
                 <Stack.Screen name="(tabs)" options={{ headerShown: false, animation: 'none' }} />

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -29,6 +29,7 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import { queryStorage } from '@/utils/mmkvStorage';
 import NetInfo from '@react-native-community/netinfo';
 import OfflineMutationReplayer from '@/offline/OfflineMutationReplayer';
+import { isLikelyNetworkError, setServerUnreachable } from '@/features/connectivity/serverReachability';
 import { QueryKeys } from '@/enums/queryKeys';
 import { clearImageMemoryCache, runImageCacheMigration } from '@/utils/images/imageCache';
 
@@ -93,7 +94,15 @@ function isQueryForActiveServer(queryKey: readonly unknown[]): boolean {
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: (_error, query) => {
+    onError: (error, query) => {
+      // A fetch-level failure (host unreachable, aborted by our timeout) marks
+      // the server unreachable; ServerReachabilityWatcher then pings to confirm
+      // and clears the flag on the first success, so a one-off blip
+      // self-corrects within seconds.
+      if (isLikelyNetworkError(error)) {
+        setServerUnreachable(true);
+      }
+
       // Only show a toast when a query has no cached data — silent background
       // refreshes shouldn't interrupt the user if stale data is still visible.
       const rootKey = query.queryKey[0];

--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -20,6 +20,7 @@ type Props = {
   disabled?: boolean;
   trailing?: React.ReactNode;
   roundedCover?: boolean;
+  showCover?: boolean;
   variant?: 'default' | 'compact';
   contentStyle?: StyleProp<ViewStyle>;
   rowStyle?: StyleProp<ViewStyle>;
@@ -34,6 +35,7 @@ export default function MediaListRow({
   disabled,
   trailing,
   roundedCover,
+  showCover = true,
   variant = 'default',
   contentStyle,
   rowStyle,
@@ -51,17 +53,19 @@ export default function MediaListRow({
           disabled={disabled || !onPress}
           activeOpacity={disabled ? 1 : 0.7}
         >
-          <MediaImage
-            cover={cover}
-            size={isCompact ? 'thumb' : 'grid'}
-            style={[
-              styles.cover,
-              isCompact && styles.compactCover,
-              roundedCover && (isCompact ? styles.compactCoverRounded : styles.coverRounded),
-            ]}
-          />
+          {showCover && (
+            <MediaImage
+              cover={cover}
+              size={isCompact ? 'thumb' : 'grid'}
+              style={[
+                styles.cover,
+                isCompact && styles.compactCover,
+                roundedCover && (isCompact ? styles.compactCoverRounded : styles.coverRounded),
+              ]}
+            />
+          )}
 
-          <View style={styles.textContainer}>
+          <View style={[styles.textContainer, !showCover && styles.textContainerNoCover]}>
             <Text
               numberOfLines={1}
               style={[isCompact ? styles.compactTitle : styles.title, { color: colors.secondary }]}
@@ -122,6 +126,9 @@ const styles = StyleSheet.create({
   textContainer: {
     flex: 1,
     marginLeft: spacing.rowGap,
+  },
+  textContainerNoCover: {
+    marginLeft: 0,
   },
   title: typography.rowTitle,
   compactTitle: typography.compactRowTitle,

--- a/src/components/rows/SongRow/index.tsx
+++ b/src/components/rows/SongRow/index.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback, useEffect, useState } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
@@ -16,7 +15,7 @@ import { Song } from '@/types';
 import SongOptions from '@/components/options/SongOptions';
 import PlaylistList from '@/components/PlaylistList';
 import { usePlayingActions } from '@/contexts/PlayingContext';
-import { MediaImage } from '@/components/MediaImage';
+import MediaListRow from '@/components/MediaListRow';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { useDownloadState } from '@/contexts/DownloadContext';
@@ -87,52 +86,30 @@ const SongRow: React.FC<Props> = ({
 
   return (
     <>
-      <View style={[styles.row, isAlbumCompact && styles.rowAlbumCompact]}>
-        <TouchableOpacity
-          style={styles.songInfo}
-          onPress={handlePress}
-          disabled={!onPress && !collection}
-        >
-          {!isAlbumCompact && (
-            <View style={styles.defaultLeading}>
-              <MediaImage
-                cover={song.cover}
-                size="thumb"
-                style={styles.cover}
-              />
-            </View>
-          )}
-
-          <View style={styles.textContainer}>
-            <Text
-              style={[styles.title, { color: colors.secondary }]}
-              numberOfLines={1}
-            >
-              {song.title}
-            </Text>
-
-            <Text
-              style={[styles.subtitle, { color: colors.subtext }]}
-              numberOfLines={1}
-            >
-              {song.artist || t('songOptions.unknownArtist')}
-              {!isAlbumCompact && ` • ${formatSongDuration(song.duration)}`}
-            </Text>
+      <MediaListRow
+        title={song.title}
+        subtitle={`${song.artist || t('songOptions.unknownArtist')}${!isAlbumCompact ? ` • ${formatSongDuration(song.duration)}` : ''}`}
+        cover={song.cover}
+        onPress={handlePress}
+        disabled={!onPress && !collection}
+        showCover={!isAlbumCompact}
+        variant="compact"
+        contentStyle={styles.mediaContent}
+        rowStyle={isAlbumCompact ? styles.mediaRowAlbumCompact : undefined}
+        trailing={
+          <View style={styles.rowRight}>
+            <Animated.View style={heartStyle}>
+              <Heart size={15} color="#ff4d67" fill="#ff4d67" />
+            </Animated.View>
+            {downloaded && (isAlbumCompact || showDownloadedDot) && (
+              <ArrowDownCircle size={16} color={colors.subtext} />
+            )}
+            <TouchableOpacity onPress={openOptions} hitSlop={10}>
+              <Ellipsis size={18} color={colors.secondary} />
+            </TouchableOpacity>
           </View>
-        </TouchableOpacity>
-
-        <View style={styles.rowRight}>
-          <Animated.View style={heartStyle}>
-            <Heart size={15} color="#ff4d67" fill="#ff4d67" />
-          </Animated.View>
-          {downloaded && (isAlbumCompact || showDownloadedDot) && (
-            <ArrowDownCircle size={16} color={colors.subtext} />
-          )}
-          <TouchableOpacity onPress={openOptions} hitSlop={10}>
-            <Ellipsis size={18} color={colors.secondary} />
-          </TouchableOpacity>
-        </View>
-      </View>
+        }
+      />
 
       <SongOptions
         ref={optionsRef}
@@ -150,51 +127,16 @@ const SongRow: React.FC<Props> = ({
 };
 
 const styles = StyleSheet.create({
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 16,
+  mediaContent: {
+    marginRight: 12,
   },
-  rowAlbumCompact: {
+  mediaRowAlbumCompact: {
     paddingVertical: 13,
-  },
-  songInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-    marginRight: 12,
-  },
-  cover: {
-    width: 44,
-    height: 44,
-    borderRadius: 6,
-    marginRight: 0,
-  },
-  defaultLeading: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginRight: 12,
-  },
-  textContainer: {
-    flex: 1,
   },
   rowRight: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-  },
-  trackNumber: {
-    fontSize: 13,
-    minWidth: 16,
-  },
-  title: {
-    fontSize: 15,
-    fontWeight: '500',
-  },
-  subtitle: {
-    fontSize: 13,
-    marginTop: 2,
   },
 });
 

--- a/src/features/connectivity/ServerReachabilityWatcher.tsx
+++ b/src/features/connectivity/ServerReachabilityWatcher.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { useNetInfo } from '@react-native-community/netinfo';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { useApi } from '@/api';
+import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
+import { usePollWhile } from '@/hooks/usePollWhile';
+import { setServerUnreachable, useServerUnreachable } from './serverReachability';
+
+const PING_TIMEOUT_MS = 5_000;
+const RECHECK_INTERVAL_MS = 10_000;
+
+function withTimeout(promise: Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  return Promise.race([
+    promise,
+    new Promise<boolean>(resolve => setTimeout(() => resolve(false), timeoutMs)),
+  ]);
+}
+
+// Confirms and recovers the server-unreachable flag. Something (typically the
+// QueryCache error handler) sets the flag on a network-level failure; this
+// watcher then pings the server — immediately, then every RECHECK_INTERVAL_MS,
+// and on app foreground / connectivity changes — and clears the flag on the
+// first successful ping, invalidating queries so stale screens refetch.
+// react-query's refetchOnReconnect can't do this: a VPN coming back up never
+// changes NetInfo state.
+export function ServerReachabilityWatcher() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const activeServer = useSelector(selectActiveServer);
+  const unreachable = useServerUnreachable();
+  const netInfo = useNetInfo();
+  const tick = usePollWhile(unreachable, RECHECK_INTERVAL_MS);
+
+  const serverId = activeServer?.id ?? null;
+  const deviceOnline = netInfo.isConnected !== false;
+
+  useEffect(() => {
+    if (!unreachable || !serverId || !deviceOnline) return;
+    let cancelled = false;
+
+    withTimeout(
+      api.auth.ping().catch(() => false),
+      PING_TIMEOUT_MS
+    ).then(ok => {
+      if (cancelled || !ok) return;
+      setServerUnreachable(false);
+      queryClient.invalidateQueries();
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // `tick` re-runs the ping while unreachable; deviceOnline re-runs it when
+    // connectivity returns.
+  }, [unreachable, tick, deviceOnline, serverId, api, queryClient]);
+
+  // A server switch resets the verdict — the new server hasn't failed yet.
+  useEffect(() => {
+    setServerUnreachable(false);
+  }, [serverId]);
+
+  // Re-check on foreground so a recovery that happened while backgrounded
+  // (VPN reconnected) is noticed immediately rather than on the next tick.
+  useEffect(() => {
+    if (!unreachable) return;
+    const sub = AppState.addEventListener('change', state => {
+      if (state !== 'active') return;
+      withTimeout(api.auth.ping().catch(() => false), PING_TIMEOUT_MS).then(ok => {
+        if (!ok) return;
+        setServerUnreachable(false);
+        queryClient.invalidateQueries();
+      });
+    });
+    return () => sub.remove();
+  }, [unreachable, api, queryClient]);
+
+  return null;
+}

--- a/src/features/connectivity/serverReachability.test.ts
+++ b/src/features/connectivity/serverReachability.test.ts
@@ -1,0 +1,39 @@
+import {
+  getServerUnreachable,
+  isLikelyNetworkError,
+  setServerUnreachable,
+} from './serverReachability'
+
+afterEach(() => {
+  setServerUnreachable(false)
+})
+
+describe('server reachability store', () => {
+  it('starts reachable and toggles', () => {
+    expect(getServerUnreachable()).toBe(false)
+    setServerUnreachable(true)
+    expect(getServerUnreachable()).toBe(true)
+    setServerUnreachable(false)
+    expect(getServerUnreachable()).toBe(false)
+  })
+})
+
+describe('isLikelyNetworkError', () => {
+  it('matches fetch-level failures', () => {
+    expect(isLikelyNetworkError(new TypeError('Network request failed'))).toBe(true)
+    expect(isLikelyNetworkError(new TypeError('Failed to fetch'))).toBe(true)
+    const abort = new Error('Aborted')
+    abort.name = 'AbortError'
+    expect(isLikelyNetworkError(abort)).toBe(true)
+  })
+
+  it('does not match HTTP errors — the server responded, it is reachable', () => {
+    expect(isLikelyNetworkError(new Error('Navidrome API error (500): boom'))).toBe(false)
+    expect(isLikelyNetworkError(new Error('Navidrome API error (401): unauthorized'))).toBe(false)
+  })
+
+  it('ignores non-error values', () => {
+    expect(isLikelyNetworkError('Network request failed')).toBe(false)
+    expect(isLikelyNetworkError(undefined)).toBe(false)
+  })
+})

--- a/src/features/connectivity/serverReachability.ts
+++ b/src/features/connectivity/serverReachability.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from 'react';
+
+// Tracks whether the active music server is reachable — a separate signal
+// from NetInfo's device connectivity. The case that needs this: the phone is
+// online but the server isn't reachable (VPN like Tailscale down, server
+// rebooting, DNS change). NetInfo reports online, so none of the offline
+// handling engages, and every query independently times out.
+//
+// Lives outside React so the module-scope QueryCache error handler in
+// app/_layout can report failures without any provider plumbing. The
+// ServerReachabilityWatcher component owns confirmation and recovery: when
+// this flips to unreachable it pings the server, clearing the flag on the
+// first success — so a one-off failed request self-corrects within one ping.
+
+let serverUnreachable = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach(listener => listener());
+}
+
+export function setServerUnreachable(value: boolean) {
+  if (serverUnreachable === value) return;
+  serverUnreachable = value;
+  emit();
+}
+
+export function getServerUnreachable(): boolean {
+  return serverUnreachable;
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useServerUnreachable(): boolean {
+  return useSyncExternalStore(subscribe, getServerUnreachable, getServerUnreachable);
+}
+
+// Fetch-level failures (host unreachable, connection refused, aborted by our
+// timeout) — as opposed to HTTP errors, which mean the server responded.
+export function isLikelyNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError') return true;
+  return /network request failed|failed to fetch|could not connect|timeout/i.test(error.message);
+}

--- a/src/hooks/albums/fallbackSongs.test.ts
+++ b/src/hooks/albums/fallbackSongs.test.ts
@@ -1,0 +1,55 @@
+import { buildFallbackAlbumSongs } from './fallbackSongs'
+import type { SongBase } from '@/types'
+
+const track = (id: string, albumId: string, overrides: Partial<SongBase> = {}): SongBase => ({
+  id,
+  title: `Track ${id}`,
+  artist: 'Artist',
+  artistId: 'artist-1',
+  cover: { kind: 'none' },
+  duration: '200',
+  albumId,
+  ...overrides,
+})
+
+describe('buildFallbackAlbumSongs', () => {
+  it('returns only the tracks belonging to the album', () => {
+    const tracks = [
+      track('a', 'album-1'),
+      track('b', 'album-2'),
+      track('c', 'album-1'),
+    ]
+
+    expect(buildFallbackAlbumSongs(tracks, 'album-1').map(s => s.id)).toEqual(['a', 'c'])
+  })
+
+  it('orders by disc then track number', () => {
+    const tracks = [
+      track('d2t1', 'album-1', { disc: 2, trackNumber: 1 }),
+      track('d1t2', 'album-1', { disc: 1, trackNumber: 2 }),
+      track('d1t1', 'album-1', { disc: 1, trackNumber: 1 }),
+    ]
+
+    expect(buildFallbackAlbumSongs(tracks, 'album-1').map(s => s.id))
+      .toEqual(['d1t1', 'd1t2', 'd2t1'])
+  })
+
+  it('sinks tracks without a track number and treats missing disc as disc 1', () => {
+    const tracks = [
+      track('unnumbered', 'album-1'),
+      track('t1', 'album-1', { trackNumber: 1 }),
+    ]
+
+    expect(buildFallbackAlbumSongs(tracks, 'album-1').map(s => s.id))
+      .toEqual(['t1', 'unnumbered'])
+  })
+
+  it('produces playable-shaped songs with an empty streamUrl for lazy resolution', () => {
+    const result = buildFallbackAlbumSongs([track('a', 'album-1')], 'album-1')
+    expect(result[0].streamUrl).toBe('')
+  })
+
+  it('returns empty for a missing album id', () => {
+    expect(buildFallbackAlbumSongs([track('a', 'album-1')], '')).toEqual([])
+  })
+})

--- a/src/hooks/albums/fallbackSongs.ts
+++ b/src/hooks/albums/fallbackSongs.ts
@@ -1,0 +1,21 @@
+import type { Song, SongBase } from '@/types';
+
+// Reconstructs an album's track list from the synced library tracks when the
+// server can't be asked (offline or unreachable). The results carry an empty
+// streamUrl — PlayingContext.resolvePlayableSong rebuilds the URL at play
+// time, preferring a downloaded local path, so these rows are fully playable
+// for downloaded content and recover automatically once the server is back.
+export function buildFallbackAlbumSongs(tracks: SongBase[], albumId: string): Song[] {
+  if (!albumId) return [];
+  return tracks
+    .filter(t => t.albumId === albumId)
+    .sort((a, b) => {
+      const discA = a.disc ?? 1;
+      const discB = b.disc ?? 1;
+      if (discA !== discB) return discA - discB;
+      const trackA = a.trackNumber ?? Number.MAX_SAFE_INTEGER;
+      const trackB = b.trackNumber ?? Number.MAX_SAFE_INTEGER;
+      return trackA - trackB;
+    })
+    .map(t => ({ ...t, streamUrl: '' }));
+}

--- a/src/hooks/albums/useAlbum.ts
+++ b/src/hooks/albums/useAlbum.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { QueryKeys } from '@/enums/queryKeys';
 import { Album } from '@/types';
@@ -6,20 +7,32 @@ import { staleTime } from '@/constants/staleTime';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { useLibrary } from '@/contexts/LibraryContext';
 import { hasValue, useOfflineFirstQuery } from '@/hooks/useOfflineFirstQuery';
+import { buildFallbackAlbumSongs } from './fallbackSongs';
 
 type UseAlbumResult = {
   album: Album | null;
   isLoading: boolean;
   songsLoading: boolean;
   error: Error | null;
+  /** True when showing library-synced data because the server couldn't be asked. */
+  degraded: boolean;
 };
 
 export function useAlbum(id: string): UseAlbumResult {
   const api = useApi();
   const activeServer = useSelector(selectActiveServer);
-  const { albums } = useLibrary();
+  const { albums, tracks } = useLibrary();
   const cachedAlbum = albums.find(a => a.id === id) ?? null;
-  const fallbackAlbum = cachedAlbum ? { ...cachedAlbum, songs: [] } : null;
+
+  // Hydrate the fallback's song list from the synced library tracks — a
+  // header with zero songs reads as a bug when the real cause is the server
+  // being unreachable. The songs resolve to local files or fresh stream URLs
+  // at play time (PlayingContext.resolvePlayableSong).
+  const fallbackSongs = useMemo(
+    () => (cachedAlbum ? buildFallbackAlbumSongs(tracks, id) : []),
+    [cachedAlbum, tracks, id]
+  );
+  const fallbackAlbum = cachedAlbum ? { ...cachedAlbum, songs: fallbackSongs } : null;
 
   const query = useOfflineFirstQuery<Album | null>({
     queryKey: [QueryKeys.Album, activeServer?.id, id],
@@ -35,5 +48,6 @@ export function useAlbum(id: string): UseAlbumResult {
     isLoading: query.isLoading,
     songsLoading: query.query.isFetching && (query.data?.songs?.length ?? 0) === 0,
     error: query.error,
+    degraded: query.degraded,
   };
 }

--- a/src/hooks/artists/useArtist.ts
+++ b/src/hooks/artists/useArtist.ts
@@ -11,6 +11,8 @@ type UseArtistResult = {
   artist: Artist | null;
   isLoading: boolean;
   error: Error | null;
+  /** True when showing library-synced data because the server couldn't be asked. */
+  degraded: boolean;
 };
 
 export function useArtist(id: string): UseArtistResult {
@@ -32,5 +34,6 @@ export function useArtist(id: string): UseArtistResult {
     artist: query.data,
     isLoading: query.isLoading,
     error: query.error,
+    degraded: query.degraded,
   };
 }

--- a/src/hooks/playlists/usePlaylist.ts
+++ b/src/hooks/playlists/usePlaylist.ts
@@ -12,6 +12,12 @@ type UsePlaylistResult = {
   isLoading: boolean;
   songsLoading: boolean;
   error: Error | null;
+  /** True when showing library-synced data because the server couldn't be asked.
+   * Unlike the album fallback, playlist membership isn't synced to Redux, so a
+   * degraded playlist that was never opened online shows no songs — the flag
+   * lets the screen say why. Previously-opened playlists restore their songs
+   * from the persisted query cache and aren't degraded. */
+  degraded: boolean;
 };
 
 export function usePlaylist(id: string): UsePlaylistResult {
@@ -35,5 +41,6 @@ export function usePlaylist(id: string): UsePlaylistResult {
     isLoading: query.isLoading,
     songsLoading: query.query.isFetching && (query.data?.songs?.length ?? 0) === 0,
     error: query.error,
+    degraded: query.degraded,
   };
 }

--- a/src/hooks/useOfflineFirstQuery.ts
+++ b/src/hooks/useOfflineFirstQuery.ts
@@ -1,5 +1,6 @@
 import { useNetInfo } from '@react-native-community/netinfo';
 import { QueryKey, useQuery } from '@tanstack/react-query';
+import { useServerUnreachable } from '@/features/connectivity/serverReachability';
 
 export function hasArrayData<T>(value: T[] | null | undefined): value is T[] {
   return Array.isArray(value) && value.length > 0;
@@ -52,12 +53,17 @@ export function useOfflineFirstQuery<T>({
   const isOffline =
     netInfo.isConnected === false ||
     netInfo.isInternetReachable === false;
+  // Circuit breaker: once the server is known-unreachable (device online but
+  // e.g. the VPN to it is down), stop issuing queries that would each hang
+  // until their own timeout. ServerReachabilityWatcher clears the flag on the
+  // first successful ping and invalidates, so these re-enable and refetch.
+  const serverUnreachable = useServerUnreachable();
   const hasFallback = hasFallbackData(fallbackData);
 
   const query = useQuery<T, Error>({
     queryKey,
     queryFn,
-    enabled: enabled && !isOffline,
+    enabled: enabled && !isOffline && !serverUnreachable,
     staleTime,
     networkMode: 'offlineFirst',
     meta: {
@@ -72,11 +78,22 @@ export function useOfflineFirstQuery<T>({
     preferFallbackWhenQueryEmpty,
   });
 
+  // Rendering the fallback because the server couldn't be asked (offline,
+  // unreachable, or the fetch failed) — as opposed to rendering server data.
+  // Screens whose fallback is thinner than the real thing surface this so
+  // partial data doesn't read as a bug.
+  const degraded =
+    query.data === undefined &&
+    hasFallback &&
+    (isOffline || serverUnreachable || query.isError);
+
   return {
     data,
-    isLoading: query.isLoading && !hasFallback,
+    isLoading: query.isLoading && !hasFallback && !isOffline && !serverUnreachable,
     error: hasFallback ? null : query.error ?? null,
     isOffline,
+    serverUnreachable,
+    degraded,
     query,
   };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -362,7 +362,8 @@
       "unexpected": "Unexpected error occurred",
       "details": "Error: {{name}} {{message}}",
       "restart": "Restart"
-    }
+    },
+    "serverUnreachableBanner": "Can't reach your server — showing local library data"
   },
   "onboarding": {
     "home": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -387,7 +387,8 @@
     },
     "more": "Plus",
     "less": "Moins",
-    "playbackError": "Impossible de lire le morceau"
+    "playbackError": "Impossible de lire le morceau",
+    "serverUnreachableBanner": "Serveur injoignable — affichage des données locales"
   },
   "onboarding": {
     "home": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -387,7 +387,8 @@
     },
     "more": "もっと見る",
     "less": "閉じる",
-    "playbackError": "曲を再生できません"
+    "playbackError": "曲を再生できません",
+    "serverUnreachableBanner": "サーバーに接続できません — ローカルのデータを表示中"
   },
   "onboarding": {
     "home": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -387,7 +387,8 @@
     },
     "more": "更多",
     "less": "收起",
-    "playbackError": "无法播放曲目"
+    "playbackError": "无法播放曲目",
+    "serverUnreachableBanner": "无法连接服务器 — 正在显示本地数据"
   },
   "onboarding": {
     "home": {

--- a/src/screens/album/index.tsx
+++ b/src/screens/album/index.tsx
@@ -2,12 +2,15 @@ import React, { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import { useRoute } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { CloudOff } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
 
 import { useAlbum, useExternalAlbum } from '@/hooks/albums';
 import { useLibrary } from '@/contexts/LibraryContext';
 import { matchAlbumToLibrary } from '@/hooks/libraryMatch';
 import { useTheme } from '@/hooks/useTheme';
 import NotFoundView from '@/components/NotFoundView';
+import StatusBanner from '@/components/StatusBanner';
 
 import AlbumContent from './components/Content';
 import LoadingAlbumContent from './components/Content/Loading';
@@ -25,6 +28,7 @@ const AlbumScreen: React.FC = () => {
   const route = useRoute<any>();
   const { id, source, albumId, artist, title, forceExternal } = (route.params ?? {}) as RouteParams;
 
+  const { t } = useTranslation();
   const { colors } = useTheme();
   const { albums } = useLibrary();
 
@@ -64,6 +68,15 @@ const AlbumScreen: React.FC = () => {
     }
     return (
       <SafeAreaView testID="album-screen" edges={['top']} style={[styles.screen, { backgroundColor: colors.background }]}>
+        {localResult.degraded && (
+          <StatusBanner
+            icon={<CloudOff size={14} color={colors.subtext} />}
+            text={t('common.serverUnreachableBanner')}
+            closable
+            style={styles.degradedBanner}
+            testID="server-unreachable-banner"
+          />
+        )}
         <AlbumContent localAlbum={localResult.album} externalAlbum={null} songsLoading={localResult.songsLoading} />
       </SafeAreaView>
     );
@@ -95,5 +108,9 @@ export default AlbumScreen;
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
+  },
+  degradedBanner: {
+    marginHorizontal: 16,
+    marginTop: 8,
   },
 });

--- a/src/screens/artist/components/Header/index.tsx
+++ b/src/screens/artist/components/Header/index.tsx
@@ -19,7 +19,6 @@ import ArtistOptions from '@/components/options/ArtistOptions';
 import { Artist, ExternalArtist, Song } from '@/types';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { toast } from '@backpackapp-io/react-native-toast';
-import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors';
 import { useArtistAlbums } from '@/hooks/artists';
 import { useTracks } from '@/hooks/tracks';
 import { buildCover } from '@/utils/builders/buildCover';
@@ -29,6 +28,7 @@ import { useSheetRef } from '@/utils/useSheetRef';
 import { useApi } from '@/api';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { fetchAlbumDetailsSettled } from '@/hooks/albums';
+import { DetailActionRow, DetailCircleAction, DetailPlayAction } from '@/components/DetailHeader';
 
 type Props = {
   localArtist: Artist | null;
@@ -213,7 +213,6 @@ function LocalActionRow({ artist }: { artist: Artist }) {
   const { isDarkMode, colors } = useTheme();
   const queryClient = useQueryClient();
   const api = useApi();
-  const themeColor = useSelector(selectThemeColor);
   const activeServer = useSelector(selectActiveServer);
 
   const { playSongInCollection } = usePlaying();
@@ -296,35 +295,34 @@ function LocalActionRow({ artist }: { artist: Artist }) {
   }, [isDownloadingAll, isArtistDownloading, isArtistFullyDownloaded, artistAlbums, downloadAlbumById]);
 
   return (
-    <View style={styles.buttonRow}>
-      <TouchableOpacity
+    <DetailActionRow style={styles.buttonRow}>
+      <DetailCircleAction
         onPress={() => void playArtist(true)}
         disabled={songsLoading}
-        style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+        style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
       >
         {songsLoading ? (
           <ActivityIndicator size="small" color={colors.secondary} />
         ) : (
           <Shuffle size={18} color={colors.secondary} />
         )}
-      </TouchableOpacity>
+      </DetailCircleAction>
 
-      <TouchableOpacity
+      <DetailPlayAction
         onPress={() => void playArtist(false)}
         disabled={songsLoading}
-        style={[styles.playButton, { backgroundColor: themeColor }]}
       >
         {songsLoading ? (
           <ActivityIndicator size="small" color="#fff" />
         ) : (
           <Play size={24} color="#fff" fill="#fff" />
         )}
-      </TouchableOpacity>
+      </DetailPlayAction>
 
-      <TouchableOpacity
+      <DetailCircleAction
         onPress={() => void handleDownloadAll()}
         disabled={isDownloadingAll || isArtistDownloading}
-        style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+        style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
       >
         {isDownloadingAll || isArtistDownloading ? (
           <ActivityIndicator size="small" color={colors.secondary} />
@@ -333,8 +331,8 @@ function LocalActionRow({ artist }: { artist: Artist }) {
         ) : (
           <Download size={18} color={colors.secondary} />
         )}
-      </TouchableOpacity>
-    </View>
+      </DetailCircleAction>
+    </DetailActionRow>
   );
 }
 
@@ -409,28 +407,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   buttonRow: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 10,
     marginBottom: 24,
   },
   secondaryButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
     backgroundColor: 'rgba(0,0,0,0.05)',
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   secondaryButtonDark: {
     backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  playButton: {
-    borderRadius: 22,
-    width: 112,
-    height: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });

--- a/src/screens/artist/index.tsx
+++ b/src/screens/artist/index.tsx
@@ -2,12 +2,15 @@ import React, { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import { useRoute } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { CloudOff } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
 
 import { useArtist, useArtists } from '@/hooks/artists';
 import { useExternalArtist } from '@/hooks/artists/useExternalArtist';
 import { matchArtistToLibrary } from '@/hooks/libraryMatch';
 import { useTheme } from '@/hooks/useTheme';
 import NotFoundView from '@/components/NotFoundView';
+import StatusBanner from '@/components/StatusBanner';
 
 import ArtistContent from './components/Content';
 import LoadingArtistContent from './components/Content/Loading';
@@ -25,6 +28,7 @@ const ArtistScreen: React.FC = () => {
   const route = useRoute<any>();
   const { id, source, artistId, mbid, name, forceExternal } = (route.params ?? {}) as RouteParams;
 
+  const { t } = useTranslation();
   const { colors } = useTheme();
   const { artists } = useArtists();
 
@@ -64,6 +68,15 @@ const ArtistScreen: React.FC = () => {
     }
     return (
       <SafeAreaView testID="artist-screen" edges={['top']} style={[styles.screen, { backgroundColor: colors.background }]}>
+        {localResult.degraded && (
+          <StatusBanner
+            icon={<CloudOff size={14} color={colors.subtext} />}
+            text={t('common.serverUnreachableBanner')}
+            closable
+            style={styles.degradedBanner}
+            testID="server-unreachable-banner"
+          />
+        )}
         <ArtistContent localArtist={localResult.artist} externalArtist={null} />
       </SafeAreaView>
     );
@@ -95,5 +108,9 @@ export default ArtistScreen;
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
+  },
+  degradedBanner: {
+    marginHorizontal: 16,
+    marginTop: 8,
   },
 });

--- a/src/screens/genre/components/Header/index.tsx
+++ b/src/screens/genre/components/Header/index.tsx
@@ -24,8 +24,8 @@ import { useTheme } from '@/hooks/useTheme'
 import { useTracks } from '@/hooks/tracks'
 import { usePlaying } from '@/contexts/PlayingContext'
 import { useDownload } from '@/contexts/DownloadContext'
-import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors'
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors'
+import { DetailActionRow, DetailCircleAction, DetailPlayAction } from '@/components/DetailHeader'
 
 type Props = {
   genre: string
@@ -37,7 +37,6 @@ const GenreHeader: React.FC<Props> = ({ genre, albums }) => {
   const queryClient = useQueryClient()
   const api = useApi()
   const { isDarkMode, colors } = useTheme()
-  const themeColor = useSelector(selectThemeColor)
   const activeServer = useSelector(selectActiveServer)
   const { playSongInCollection } = usePlaying()
   const { downloadAlbumById, getCollectionDownloadState } = useDownload()
@@ -175,35 +174,34 @@ const GenreHeader: React.FC<Props> = ({ genre, albums }) => {
         </Text>
       </View>
 
-      <View style={styles.buttonRow}>
-        <TouchableOpacity
+      <DetailActionRow style={styles.buttonRow}>
+        <DetailCircleAction
           onPress={() => { void play(true) }}
           disabled={songsLoading}
-          style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+          style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
         >
           {songsLoading ? (
             <ActivityIndicator size="small" color={colors.secondary} />
           ) : (
             <Shuffle size={18} color={colors.secondary} />
           )}
-        </TouchableOpacity>
+        </DetailCircleAction>
 
-        <TouchableOpacity
+        <DetailPlayAction
           onPress={() => { void play(false) }}
           disabled={songsLoading}
-          style={[styles.playButton, { backgroundColor: themeColor }]}
         >
           {songsLoading ? (
             <ActivityIndicator size="small" color="#fff" />
           ) : (
             <Play size={24} color="#fff" fill="#fff" />
           )}
-        </TouchableOpacity>
+        </DetailPlayAction>
 
-        <TouchableOpacity
+        <DetailCircleAction
           onPress={() => { void handleDownloadAll() }}
           disabled={isDownloadingAll || isDownloading}
-          style={[styles.secondaryButton, isDarkMode && styles.secondaryButtonDark]}
+          style={isDarkMode ? styles.secondaryButtonDark : styles.secondaryButton}
         >
           {isDownloadingAll || isDownloading ? (
             <ActivityIndicator size="small" color={colors.secondary} />
@@ -212,8 +210,8 @@ const GenreHeader: React.FC<Props> = ({ genre, albums }) => {
           ) : (
             <Download size={18} color={colors.secondary} />
           )}
-        </TouchableOpacity>
-      </View>
+        </DetailCircleAction>
+      </DetailActionRow>
     </>
   )
 }
@@ -259,28 +257,12 @@ const styles = StyleSheet.create({
     marginTop: 6,
   },
   buttonRow: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 10,
     marginBottom: 24,
   },
   secondaryButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
     backgroundColor: 'rgba(0,0,0,0.05)',
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   secondaryButtonDark: {
     backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  playButton: {
-    borderRadius: 22,
-    width: 112,
-    height: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 })

--- a/src/screens/home/components/QuickPicksSection/index.tsx
+++ b/src/screens/home/components/QuickPicksSection/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
-  TouchableOpacity,
   ScrollView,
   StyleSheet,
   useWindowDimensions,
@@ -14,7 +13,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/hooks/useTheme';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { usePlayableSongResolver } from '@/hooks/songs';
-import { MediaImage } from '@/components/MediaImage';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import SongOptions from '@/components/options/SongOptions';
 import PlaylistList from '@/components/PlaylistList';
 import { useSheetRef } from '@/utils/useSheetRef';
@@ -32,7 +32,6 @@ const TOTAL_PAGES = 3;
 const TOTAL_PICKS = PAGE_SIZE * TOTAL_PAGES;
 const CANDIDATE_POOL = TOTAL_PICKS * 2; // draw from a wider pool on refresh
 const H_PADDING = 12;
-const IMG_SIZE = 44;
 const DECAY_MS = 7 * 24 * 60 * 60 * 1000;
 const PEEK = 28; // pixels of the next page visible at the right edge
 
@@ -153,31 +152,24 @@ export default function QuickPicksSection({ refreshKey = 0 }: Props) {
             {pages.map((page, pageIdx) => (
               <View key={pageIdx} style={[styles.page, { width: screenWidth - PEEK }]}>
                 {page.map(song => (
-                  <TouchableOpacity
+                  <MediaListRow
                     key={song.id}
-                    style={styles.row}
+                    title={song.title}
+                    subtitle={song.artist}
+                    cover={song.cover}
                     onPress={() => { void handlePress(song); }}
-                    activeOpacity={0.7}
-                  >
-                    <MediaImage cover={song.cover} size="thumb" style={styles.art} />
-                    <View style={styles.info}>
-                      <Text style={[styles.trackTitle, { color: colors.secondary }]} numberOfLines={1}>
-                        {song.title}
-                      </Text>
-                      <Text style={[styles.trackArtist, { color: colors.subtext }]} numberOfLines={1}>
-                        {song.artist}
-                      </Text>
-                    </View>
-                    <TouchableOpacity
-                      onPress={() => { void handleOptions(song); }}
-                      hitSlop={10}
-                    >
-                      <Ellipsis
-                        size={18}
-                        color={colors.secondary}
+                    variant="compact"
+                    style={styles.rowWrapper}
+                    rowStyle={styles.row}
+                    trailing={
+                      <IconActionButton
+                        icon={<Ellipsis size={18} color={colors.secondary} />}
+                        onPress={() => { void handleOptions(song); }}
+                        accessibilityLabel={`${song.title} options`}
+                        size="compact"
                       />
-                    </TouchableOpacity>
-                  </TouchableOpacity>
+                    }
+                  />
                 ))}
               </View>
             ))}
@@ -216,27 +208,11 @@ const styles = StyleSheet.create({
   page: {
     gap: 2,
   },
+  rowWrapper: {
+    paddingHorizontal: 0,
+  },
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
     paddingHorizontal: H_PADDING,
     paddingVertical: 6,
-    gap: 12,
-  },
-  art: {
-    width: IMG_SIZE,
-    height: IMG_SIZE,
-    borderRadius: 4,
-  },
-  info: {
-    flex: 1,
-    gap: 2,
-  },
-  trackTitle: {
-    fontSize: 15,
-    fontWeight: '500',
-  },
-  trackArtist: {
-    fontSize: 13,
   },
 });

--- a/src/screens/playlist/index.tsx
+++ b/src/screens/playlist/index.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import { useRoute } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { CloudOff } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
 
 import { usePlaylist } from '@/hooks/playlists';
 import { useTheme } from '@/hooks/useTheme';
 import NotFoundView from '@/components/NotFoundView';
+import StatusBanner from '@/components/StatusBanner';
 
 import PlaylistContent from './components/Content';
 import LoadingPlaylistContent from './components/Content/Loading';
@@ -14,8 +17,9 @@ const PlaylistScreen: React.FC = () => {
   const route = useRoute<any>();
   const { id } = route.params;
 
+  const { t } = useTranslation();
   const { colors } = useTheme();
-  const { playlist, isLoading, songsLoading } = usePlaylist(id);
+  const { playlist, isLoading, songsLoading, degraded } = usePlaylist(id);
 
   if (isLoading) {
     return (
@@ -31,6 +35,15 @@ const PlaylistScreen: React.FC = () => {
 
   return (
     <SafeAreaView testID="playlist-screen" edges={['top']} style={[styles.screen, { backgroundColor: colors.background }]}>
+      {degraded && (
+        <StatusBanner
+          icon={<CloudOff size={14} color={colors.subtext} />}
+          text={t('common.serverUnreachableBanner')}
+          closable
+          style={styles.degradedBanner}
+          testID="server-unreachable-banner"
+        />
+      )}
       <PlaylistContent playlist={playlist} songsLoading={songsLoading} />
     </SafeAreaView>
   );
@@ -41,5 +54,9 @@ export default PlaylistScreen;
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
+  },
+  degradedBanner: {
+    marginHorizontal: 16,
+    marginTop: 8,
   },
 });

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -21,7 +21,8 @@ import LoadingAlbumRow from '@/components/rows/AlbumRow/Loading';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { usePlaying } from '@/contexts/PlayingContext';
-import { MediaImage } from '@/components/MediaImage';
+import IconActionButton from '@/components/IconActionButton';
+import MediaListRow from '@/components/MediaListRow';
 import SongOptions from '@/components/options/SongOptions';
 import PlaylistList from '@/components/PlaylistList';
 import { Song } from '@/types';
@@ -131,30 +132,20 @@ const Search = () => {
   const renderResult = (result: SearchResult) => {
     if (result.type === 'song') {
       return (
-        <View style={styles.songWrapper}>
-          <View style={styles.songRow}>
-            <TouchableOpacity
-              accessibilityLabel={`Search result song ${result.title}`}
-              accessibilityRole="button"
-              testID="search-song-result"
-              style={styles.songInfo}
-              onPress={() => { void handleSongPress(result); }}
-            >
-              <MediaImage cover={result.cover} size="thumb" style={styles.songCover} />
-              <View style={styles.songText}>
-                <Text numberOfLines={1} style={[styles.songTitle, { color: colors.secondary }]}>
-                  {result.title}
-                </Text>
-                <Text numberOfLines={1} style={[styles.songSubtitle, { color: colors.subtext }]}>
-                  {result.subtext}
-                </Text>
-              </View>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.songOptionsButton} onPress={() => { void handleSongOptions(result); }}>
-              <Ellipsis size={24} color={colors.secondary} />
-            </TouchableOpacity>
-          </View>
-        </View>
+        <MediaListRow
+          title={result.title}
+          subtitle={result.subtext}
+          cover={result.cover}
+          onPress={() => { void handleSongPress(result); }}
+          trailing={
+            <IconActionButton
+              icon={<Ellipsis size={24} color={colors.secondary} />}
+              onPress={() => { void handleSongOptions(result); }}
+              accessibilityLabel={`Search result song ${result.title} options`}
+              size="compact"
+            />
+          }
+        />
       );
     }
 
@@ -386,38 +377,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 24,
     fontSize: 16,
-  },
-  songWrapper: {
-    paddingHorizontal: 16,
-  },
-  songRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  songInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  songCover: {
-    width: 64,
-    height: 64,
-    borderRadius: 6,
-  },
-  songText: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  songTitle: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  songSubtitle: {
-    fontSize: 14,
-    marginTop: 2,
-  },
-  songOptionsButton: {
-    padding: 8,
   },
 });

--- a/src/types/Song.ts
+++ b/src/types/Song.ts
@@ -12,6 +12,10 @@ export interface SongBase {
     albumId: string;
     /** Album title — populated from server response, used for lock screen Now Playing display. */
     albumTitle?: string;
+    /** Disc number; omitted when not available. */
+    disc?: number;
+    /** Track number; omitted when not available. */
+    trackNumber?: number;
     year?: number;
     dateAdded?: string;
     /** Server-reported play count — populated during sync, extracted into serverSongPlays Redux state. */
@@ -38,10 +42,6 @@ export interface Song extends SongBase {
     mimeType?: string;
     /** Release date; omitted when not available. */
     dateReleased?: string;
-    /** Disc number; omitted when not available. */
-    disc?: number;
-    /** Track number; omitted when not available. */
-    trackNumber?: number;
     /** Date added to library; omitted when not available. */
     dateAdded?: string;
     /** BPM; omitted when not available. */


### PR DESCRIPTION
## Summary

Fixes the "opened an album while Tailscale was down and it showed 0 songs — looked like an app bug" experience. The device being online while the server is unreachable previously engaged none of the offline handling: NetInfo said online, every query hung for its own 30s timeout, the album fallback had `songs: []`, and the error was swallowed because a fallback existed.

- **Server-reachability signal** (`src/features/connectivity/`): the global QueryCache error handler flags fetch-level failures (`AbortError`, network-request-failed — not HTTP errors, which prove the server responded). `ServerReachabilityWatcher` confirms by pinging (5s timeout) and recovers: every 10s while down, plus on app foreground and connectivity changes. On the first successful ping it clears the flag and invalidates queries, so screens refetch. `refetchOnReconnect` can't cover this — a VPN reconnecting never changes NetInfo state.
- **Circuit breaker**: `useOfflineFirstQuery` disables queries while the server is known-unreachable, so screens stop paying an individual 30s timeout each, and re-enable automatically on recovery.
- **Hydrated album fallback**: the fallback song list is rebuilt from the synced library tracks (`buildFallbackAlbumSongs`, unit-tested), ordered by disc/track via new `disc`/`trackNumber` fields carried through both server adapters (Subsonic `discNumber`/`track`, Jellyfin/Emby `ParentIndexNumber`/`IndexNumber`). Rows resolve at play time via `PlayingContext.resolvePlayableSong` — downloaded content plays from local files; the rest recovers when the server returns.
- **`degraded` flag + StatusBanner**: `useOfflineFirstQuery` exposes when it's rendering fallback because the server couldn't be asked; album and artist screens show a closable banner ("Can't reach your server — showing local library data", en/fr/ja/zh). The banner reuses the extracted `StatusBanner` component shared with the album header's in-library/downloading pills.

## Testing

- `npx jest --ci`: 27 suites / 116 tests (9 new: fallback song ordering, reachability store, network-error classification)
- `npx tsc --noEmit` and `npm run lint`: clean
- Not exercised on-device. The real-world validation is the original repro: kill the VPN, open a synced album → full track list + banner instead of 0 songs; reconnect the VPN → banner clears and content refreshes within ~10s without reopening the screen.

## Follow-ups (out of scope here)

- Playlist screens now show the same degraded banner (second commit). Full offline hydration of never-opened playlists still needs membership synced into the library slice — separate, sync-architecture-sized change.
- The Maestro flow for detail screens could assert the banner appears when the server is blackholed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
