### PR TITLE
Consolidate option sheets onto shared OptionSheet primitives

### DIFF
--- a/src/components/ExternalSourcePickerSheet/index.tsx
+++ b/src/components/ExternalSourcePickerSheet/index.tsx
@@ -6,6 +6,12 @@ import { renderBackdrop } from '@/components/BottomSheetBackdrop'
 import { getSourceMeta } from '@/features/sources/registry'
 import { MediaImage } from '@/components/MediaImage'
 import type { SourceResolvedAlbum, SourceResolvedArtist } from '@/features/sources/registry'
+import {
+  OptionSheetDivider,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from '@/components/options/OptionSheetPrimitives'
 
 export type PickerItemAlbum = SourceResolvedAlbum & { kind: 'album' }
 export type PickerItemArtist = SourceResolvedArtist & { kind: 'artist' }
@@ -21,8 +27,8 @@ const COVER_SIZE = 48
 
 const ExternalSourcePickerSheet = forwardRef<BottomSheetModal, Props>(
   ({ items, isLoading, onSelect }, ref) => {
-    const { isDarkMode, colors } = useTheme()
-    const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background }
+    const { colors } = useTheme()
+    const sheetBg = useOptionSheetBackground()
 
     const grouped = items.reduce<Record<string, PickerItem[]>>((acc, item) => {
       if (!acc[item.source]) acc[item.source] = []
@@ -37,10 +43,10 @@ const ExternalSourcePickerSheet = forwardRef<BottomSheetModal, Props>(
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
         stackBehavior="push"
       >
-        <BottomSheetScrollView style={sheetBg} contentContainerStyle={styles.sheetContent}>
+        <BottomSheetScrollView style={sheetBg} contentContainerStyle={optionSheetStyles.sheetContent}>
           {isLoading && (
             <View style={styles.loading}>
               <ActivityIndicator size="large" color={colors.subtext} />
@@ -58,10 +64,8 @@ const ExternalSourcePickerSheet = forwardRef<BottomSheetModal, Props>(
             const sourceLabel = meta?.label ?? sourceId
             return (
               <View key={sourceId}>
-                {groupIndex > 0 && (
-                  <View style={[styles.divider, { backgroundColor: colors.border }]} />
-                )}
-                <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{sourceLabel}</Text>
+                {groupIndex > 0 && <OptionSheetDivider />}
+                <OptionSheetSectionLabel label={sourceLabel} />
                 {sourceItems.map((item, i) => {
                   const label = item.kind === 'album' ? item.title : item.name
                   const sublabel = item.kind === 'album' ? (item as SourceResolvedAlbum).artist : undefined
@@ -105,14 +109,6 @@ ExternalSourcePickerSheet.displayName = 'ExternalSourcePickerSheet'
 export default ExternalSourcePickerSheet
 
 const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
   loading: {
     paddingVertical: 32,
     alignItems: 'center',
@@ -121,15 +117,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     textAlign: 'center',
     paddingVertical: 24,
-  },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
   },
   option: {
     flexDirection: 'row',

--- a/src/components/options/AlbumOptions.tsx
+++ b/src/components/options/AlbumOptions.tsx
@@ -1,11 +1,5 @@
 import React, { forwardRef, useMemo, useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ActivityIndicator,
-} from 'react-native';
+import { View, ActivityIndicator } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetScrollView,
@@ -14,7 +8,6 @@ import { Heart, ListEnd, ListStart, Play, Shuffle, Disc, CheckCircle, ArrowDownC
 import { toast } from '@backpackapp-io/react-native-toast';
 
 import { Album, AlbumBase } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import { useSelector } from 'react-redux';
 import { selectAlbumPlayCount } from '@/utils/redux/selectors/statsSelectors';
 import { usePlaying } from '@/contexts/PlayingContext';
@@ -26,6 +19,16 @@ import { useTranslation } from 'react-i18next';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import { useLazyAlbumDetail } from './useLazyCollectionDetails';
 import { useStarredAlbums, useStarAlbum, useUnstarAlbum } from '@/hooks/starred';
+import {
+  OptionSheetChipsRow,
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetInfoRow,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 export type AlbumOptionsProps = {
   album: AlbumBase | Album | null;
@@ -38,7 +41,7 @@ const AlbumOptions = forwardRef<
   AlbumOptionsProps
 >(({ album, hideGoToAlbum }, ref) => {
   const { t } = useTranslation();
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
   const router = useRouter();
   const enabledSources = useEnabledExternalSources();
 
@@ -65,8 +68,7 @@ const AlbumOptions = forwardRef<
 
   const isStarred = starredAlbums.some(a => a.id === album?.id);
 
-  const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
-  const genreChipBg = isDarkMode ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)';
+  const sheetBg = useOptionSheetBackground();
 
   const close = () => {
     (ref as any)?.current?.dismiss();
@@ -173,9 +175,9 @@ const AlbumOptions = forwardRef<
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       >
-        <View style={[styles.loading, sheetBg]}>
+        <View style={[optionSheetStyles.loading, sheetBg]}>
           <ActivityIndicator size="large" color={colors.subtext} />
         </View>
       </BottomSheetModal>
@@ -191,164 +193,119 @@ const AlbumOptions = forwardRef<
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       handleIndicatorStyle={{ backgroundColor: colors.border }}
-      backgroundStyle={[styles.sheetBackground, sheetBg]}
+      backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       stackBehavior="push"
       onChange={(index) => setIsSheetOpen(index >= 0)}
     >
       <BottomSheetScrollView
         style={sheetBg}
-        contentContainerStyle={styles.sheetContent}
+        contentContainerStyle={optionSheetStyles.sheetContent}
       >
-        <View style={styles.header}>
-          <MediaImage cover={album.cover} size="grid" style={styles.cover} />
-          <View style={styles.headerText}>
-            <Text
-              style={[styles.title, { color: colors.secondary }]}
-              numberOfLines={2}
-            >
-              {album.title}
-            </Text>
-            <Text
-              style={[styles.artist, { color: colors.subtext }]}
-              numberOfLines={1}
-            >
-              {album.artist?.name ?? ''}
-            </Text>
-          </View>
-        </View>
+        <OptionSheetHeader
+          cover={album.cover}
+          title={album.title}
+          subtitle={album.artist?.name ?? ''}
+          titleLines={2}
+        />
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <TouchableOpacity
-          style={styles.option}
+        <OptionSheetRow
+          icon={<Heart size={26} color="#ff3b30" fill={isStarred ? '#ff3b30' : 'none'} />}
+          label={isStarred ? t('albumOptions.actions.unfavorite') : t('albumOptions.actions.favorite')}
           onPress={toggleFavorite}
-        >
-          <Heart size={26} color="#ff3b30" fill={isStarred ? '#ff3b30' : 'none'} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>
-            {isStarred ? t('albumOptions.actions.unfavorite') : t('albumOptions.actions.favorite')}
-          </Text>
-        </TouchableOpacity>
+        />
 
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+        <OptionSheetRow
+          icon={<Play size={26} color={colors.secondary} fill={colors.secondary} />}
+          label={t('albumOptions.actions.play')}
           onPress={() => handlePlay(false)}
           disabled={playbackDisabled}
-        >
-          {songsLoading ? (
-            <ActivityIndicator size="small" color={colors.subtext} />
-          ) : (
-            <Play size={26} color={colors.secondary} fill={colors.secondary} />
-          )}
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.play')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+          loading={songsLoading}
+        />
+        <OptionSheetRow
+          icon={<Shuffle size={26} color={colors.secondary} />}
+          label={t('albumOptions.actions.shuffle')}
           onPress={() => handlePlay(true)}
           disabled={playbackDisabled}
-        >
-          <Shuffle size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.shuffle')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<ListStart size={26} color={colors.secondary} />}
+          label={t('albumOptions.actions.addToNext')}
           onPress={handleAddToNext}
           disabled={playbackDisabled}
-        >
-          <ListStart size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.addToNext')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<ListEnd size={26} color={colors.secondary} />}
+          label={t('albumOptions.actions.addToEnd')}
           onPress={handleAddToEnd}
           disabled={playbackDisabled}
-        >
-          <ListEnd size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.addToEnd')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<Shuffle size={26} color={colors.secondary} />}
+          label={t('albumOptions.actions.shuffleToQueue')}
           onPress={handleShuffleToQueue}
           disabled={playbackDisabled}
-        >
-          <Shuffle size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.shuffleToQueue')}</Text>
-        </TouchableOpacity>
+          dimRow={playbackDisabled}
+        />
 
         {!hideGoToAlbum && (
-          <TouchableOpacity style={styles.option} onPress={handleGoToAlbum}>
-            <Disc size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.goToAlbum')}</Text>
-          </TouchableOpacity>
+          <OptionSheetRow
+            icon={<Disc size={26} color={colors.secondary} />}
+            label={t('albumOptions.actions.goToAlbum')}
+            onPress={handleGoToAlbum}
+          />
         )}
 
         {enabledSources.length > 0 && !!album.artist?.name && (
-          <TouchableOpacity style={styles.option} onPress={handleViewExternal}>
-            <Globe size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>{t('albumOptions.actions.viewExternal')}</Text>
-          </TouchableOpacity>
+          <OptionSheetRow
+            icon={<Globe size={26} color={colors.secondary} />}
+            label={t('albumOptions.actions.viewExternal')}
+            onPress={handleViewExternal}
+          />
         )}
 
-        <TouchableOpacity
-          style={styles.option}
+        <OptionSheetRow
+          icon={
+            isDownloaded ? (
+              <CheckCircle size={26} color={colors.subtext} />
+            ) : (
+              <ArrowDownCircle size={26} color={colors.secondary} />
+            )
+          }
+          label={isDownloading ? t('albumOptions.actions.downloading') : isDownloaded ? t('albumOptions.actions.downloaded') : t('albumOptions.actions.download')}
           onPress={handleDownload}
           disabled={isDownloaded || isDownloading}
-        >
-          {isDownloading ? (
-            <ActivityIndicator size="small" color={colors.subtext} />
-          ) : isDownloaded ? (
-            <CheckCircle size={26} color={colors.subtext} />
-          ) : (
-            <ArrowDownCircle size={26} color={colors.secondary} />
-          )}
-          <Text
-            style={[
-              styles.optionText,
-              { color: colors.secondary },
-              (isDownloaded || isDownloading) && { opacity: 0.6 },
-            ]}
-          >
-            {isDownloading ? t('albumOptions.actions.downloading') : isDownloaded ? t('albumOptions.actions.downloaded') : t('albumOptions.actions.download')}
-          </Text>
-        </TouchableOpacity>
+          loading={isDownloading}
+          dimLabel={isDownloaded || isDownloading}
+        />
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('albumOptions.sections.albumInfo')}</Text>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('albumOptions.info.artist')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]} numberOfLines={1}>
-            {album.artist?.name ?? t('albumOptions.info.unknown')}
-          </Text>
-        </View>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('albumOptions.info.year')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>{album.year ?? t('albumOptions.info.unknown')}</Text>
-        </View>
+        <OptionSheetSectionLabel label={t('albumOptions.sections.albumInfo')} />
+        <OptionSheetInfoRow
+          label={t('albumOptions.info.artist')}
+          value={album.artist?.name ?? t('albumOptions.info.unknown')}
+          valueLines={1}
+        />
+        <OptionSheetInfoRow
+          label={t('albumOptions.info.year')}
+          value={album.year ?? t('albumOptions.info.unknown')}
+        />
         {album.genres?.length ? (
-          <View style={styles.genreRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('albumOptions.info.genres')}</Text>
-            <View style={styles.genreList}>
-              {album.genres.map((g, i) => (
-                <View key={`${g}-${i}`} style={[styles.genreChip, { backgroundColor: genreChipBg }]}>
-                  <Text style={[styles.genreChipText, { color: colors.secondary }]}>{g}</Text>
-                </View>
-              ))}
-            </View>
-          </View>
+          <OptionSheetChipsRow label={t('albumOptions.info.genres')} values={album.genres} />
         ) : (
-          <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('albumOptions.info.genres')}</Text>
-            <Text style={[styles.infoValue, { color: colors.secondary }]}>{t('albumOptions.info.unknown')}</Text>
-          </View>
+          <OptionSheetInfoRow
+            label={t('albumOptions.info.genres')}
+            value={t('albumOptions.info.unknown')}
+          />
         )}
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('albumOptions.info.songs')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>{songs.length}</Text>
-        </View>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('albumOptions.info.plays')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>{playCount}</Text>
-        </View>
+        <OptionSheetInfoRow label={t('albumOptions.info.songs')} value={songs.length} />
+        <OptionSheetInfoRow label={t('albumOptions.info.plays')} value={playCount} />
       </BottomSheetScrollView>
     </BottomSheetModal>
     </>
@@ -358,82 +315,3 @@ const AlbumOptions = forwardRef<
 AlbumOptions.displayName = 'AlbumOptions';
 
 export default AlbumOptions;
-
-const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
-  loading: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 48,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '500' },
-  artist: { fontSize: 14, marginTop: 2 },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionDisabled: {
-    opacity: 0.55,
-  },
-  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500' },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  infoRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-  },
-  infoLabel: { fontSize: 14 },
-  infoValue: { fontSize: 14, fontWeight: '500', marginLeft: 12, flex: 1, textAlign: 'right' },
-  genreRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    paddingVertical: 8,
-  },
-  genreList: {
-    flex: 1,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-    marginLeft: 12,
-    justifyContent: 'flex-end',
-    alignContent: 'flex-end',
-  },
-  genreChip: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 12,
-  },
-  genreChipText: {
-    fontSize: 13,
-    fontWeight: '500',
-  },
-});

--- a/src/components/options/ArtistOptions.tsx
+++ b/src/components/options/ArtistOptions.tsx
@@ -1,11 +1,5 @@
 import React, { forwardRef, useCallback, useMemo, useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ActivityIndicator,
-} from 'react-native';
+import { View, ActivityIndicator } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetScrollView,
@@ -13,7 +7,6 @@ import {
 import { ListEnd, Play, Shuffle, CheckCircle, ArrowDownCircle, User, Globe } from 'lucide-react-native';
 
 import { Artist, Song } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useRouter } from 'expo-router';
 import { useSelector } from 'react-redux';
@@ -26,6 +19,15 @@ import { useDownload } from '@/contexts/DownloadContext';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import { useLazyArtistSongs } from './useLazyCollectionDetails';
+import {
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetInfoRow,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 export type ArtistOptionsProps = {
   artist: Artist | null;
@@ -38,7 +40,7 @@ const ArtistOptions = forwardRef<
   ArtistOptionsProps
 >(({ artist, hideGoToArtist }, ref) => {
   const { t } = useTranslation();
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
   const router = useRouter();
 
   const {
@@ -63,7 +65,7 @@ const ArtistOptions = forwardRef<
   );
 
 
-  const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
+  const sheetBg = useOptionSheetBackground();
 
   const close = useCallback(() => {
     (ref as any)?.current?.dismiss();
@@ -175,9 +177,9 @@ const ArtistOptions = forwardRef<
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       >
-        <View style={[styles.loading, sheetBg]}>
+        <View style={[optionSheetStyles.loading, sheetBg]}>
           <ActivityIndicator size="large" color={colors.subtext} />
         </View>
       </BottomSheetModal>
@@ -193,119 +195,92 @@ const ArtistOptions = forwardRef<
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       handleIndicatorStyle={{ backgroundColor: colors.border }}
-      backgroundStyle={[styles.sheetBackground, sheetBg]}
+      backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       stackBehavior="push"
       onChange={(index) => setIsSheetOpen(index >= 0)}
     >
       <BottomSheetScrollView
         style={sheetBg}
-        contentContainerStyle={styles.sheetContent}
+        contentContainerStyle={optionSheetStyles.sheetContent}
       >
-        <View style={styles.header}>
-          <MediaImage cover={artist.cover} size="grid" style={styles.cover} />
-          <View style={styles.headerText}>
-            <Text
-              style={[styles.title, { color: colors.secondary }]}
-              numberOfLines={2}
-            >
-              {artist.name}
-            </Text>
-            <Text style={[styles.artist, { color: colors.subtext }]}>{t('artistOptions.artistLabel')}</Text>
-          </View>
-        </View>
+        <OptionSheetHeader
+          cover={artist.cover}
+          title={artist.name}
+          subtitle={t('artistOptions.artistLabel')}
+          titleLines={2}
+        />
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+        <OptionSheetRow
+          icon={<Play size={26} color={colors.secondary} fill={colors.secondary} />}
+          label={t('artistOptions.actions.play')}
           onPress={() => handlePlay(false)}
           disabled={playbackDisabled}
-        >
-          {songsLoading ? (
-            <ActivityIndicator size="small" color={colors.subtext} />
-          ) : (
-            <Play size={26} color={colors.secondary} fill={colors.secondary} />
-          )}
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('artistOptions.actions.play')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+          loading={songsLoading}
+        />
+        <OptionSheetRow
+          icon={<Shuffle size={26} color={colors.secondary} />}
+          label={t('artistOptions.actions.shuffle')}
           onPress={() => handlePlay(true)}
           disabled={playbackDisabled}
-        >
-          <Shuffle size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('artistOptions.actions.shuffle')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<ListEnd size={26} color={colors.secondary} />}
+          label={t('artistOptions.actions.addToQueue')}
           onPress={handleAddToQueue}
           disabled={playbackDisabled}
-        >
-          <ListEnd size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('artistOptions.actions.addToQueue')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<Shuffle size={26} color={colors.secondary} />}
+          label={t('artistOptions.actions.shuffleToQueue')}
           onPress={handleShuffleToQueue}
           disabled={playbackDisabled}
-        >
-          <Shuffle size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('artistOptions.actions.shuffleToQueue')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.option}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={
+            isDownloaded ? (
+              <CheckCircle size={26} color={colors.subtext} />
+            ) : (
+              <ArrowDownCircle size={26} color={colors.secondary} />
+            )
+          }
+          label={isDownloading
+            ? t('artistOptions.actions.downloading')
+            : isDownloaded
+              ? t('artistOptions.actions.downloaded')
+              : t('artistOptions.actions.download')}
           onPress={() => { void handleDownloadAll(); }}
           disabled={isDownloaded || isDownloading}
-        >
-          {isDownloading ? (
-            <ActivityIndicator size="small" color={colors.subtext} />
-          ) : isDownloaded ? (
-            <CheckCircle size={26} color={colors.subtext} />
-          ) : (
-            <ArrowDownCircle size={26} color={colors.secondary} />
-          )}
-          <Text
-            style={[
-              styles.optionText,
-              { color: colors.secondary },
-              (isDownloaded || isDownloading) && { opacity: 0.6 },
-            ]}
-          >
-            {isDownloading
-              ? t('artistOptions.actions.downloading')
-              : isDownloaded
-                ? t('artistOptions.actions.downloaded')
-                : t('artistOptions.actions.download')}
-          </Text>
-        </TouchableOpacity>
+          loading={isDownloading}
+          dimLabel={isDownloaded || isDownloading}
+        />
 
         {!hideGoToArtist && (
-          <TouchableOpacity style={styles.option} onPress={handleGoToArtist}>
-            <User size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>{t('artistOptions.actions.goToArtist')}</Text>
-          </TouchableOpacity>
+          <OptionSheetRow
+            icon={<User size={26} color={colors.secondary} />}
+            label={t('artistOptions.actions.goToArtist')}
+            onPress={handleGoToArtist}
+          />
         )}
 
         {enabledSources.length > 0 && (
-          <TouchableOpacity style={styles.option} onPress={handleViewExternal}>
-            <Globe size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>{t('artistOptions.actions.viewExternal')}</Text>
-          </TouchableOpacity>
+          <OptionSheetRow
+            icon={<Globe size={26} color={colors.secondary} />}
+            label={t('artistOptions.actions.viewExternal')}
+            onPress={handleViewExternal}
+          />
         )}
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('artistOptions.sections.info')}</Text>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('artistOptions.info.albums')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>
-            {artistAlbums.length}
-          </Text>
-        </View>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('artistOptions.info.plays')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>{playCount}</Text>
-        </View>
+        <OptionSheetSectionLabel label={t('artistOptions.sections.info')} />
+        <OptionSheetInfoRow label={t('artistOptions.info.albums')} value={artistAlbums.length} />
+        <OptionSheetInfoRow label={t('artistOptions.info.plays')} value={playCount} />
       </BottomSheetScrollView>
     </BottomSheetModal>
     </>
@@ -315,59 +290,3 @@ const ArtistOptions = forwardRef<
 ArtistOptions.displayName = 'ArtistOptions';
 
 export default ArtistOptions;
-
-const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
-  loading: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 48,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '500' },
-  artist: { fontSize: 14, marginTop: 2 },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionDisabled: {
-    opacity: 0.55,
-  },
-  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500' },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  infoRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-  },
-  infoLabel: { fontSize: 14 },
-  infoValue: { fontSize: 14, fontWeight: '500', marginLeft: 12, flex: 1, textAlign: 'right' },
-});

--- a/src/components/options/DownloadSheet.tsx
+++ b/src/components/options/DownloadSheet.tsx
@@ -1,10 +1,5 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetScrollView,
@@ -12,7 +7,6 @@ import {
 import { toast } from '@backpackapp-io/react-native-toast';
 
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
-import { MediaImage } from '@/components/MediaImage';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +16,14 @@ import {
   type DownloaderState,
 } from '@/features/downloaders/registry';
 import type { ExternalAlbumBase } from '@/types';
+import {
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 interface Props {
   album: ExternalAlbumBase;
@@ -32,7 +34,7 @@ interface Props {
 
 const DownloadSheet: React.FC<Props> = ({ album, track, sheetRef }) => {
   const { t } = useTranslation();
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
 
   const downloaders = useDownloaderStates();
   const available = downloaders.filter(
@@ -42,7 +44,7 @@ const DownloadSheet: React.FC<Props> = ({ album, track, sheetRef }) => {
   const [loadingId, setLoadingId] = useState<DownloaderId | null>(null);
   const anyLoading = loadingId !== null;
 
-  const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
+  const sheetBg = useOptionSheetBackground();
 
   const handleDownload = async ({ def, config }: DownloaderState) => {
     if (anyLoading) return;
@@ -76,46 +78,29 @@ const DownloadSheet: React.FC<Props> = ({ album, track, sheetRef }) => {
       backdropComponent={renderBackdrop}
       stackBehavior="push"
       handleIndicatorStyle={{ backgroundColor: colors.border }}
-      backgroundStyle={[styles.sheetBackground, sheetBg]}
+      backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
     >
       <BottomSheetScrollView style={sheetBg} contentContainerStyle={styles.content}>
-        <View style={styles.header}>
-          <MediaImage cover={album.cover} size="grid" style={styles.cover} />
-          <View style={styles.headerText}>
-            <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={1}>
-              {headerTitle}
-            </Text>
-            <Text style={[styles.artist, { color: colors.subtext }]} numberOfLines={1}>
-              {headerSubtext}
-            </Text>
-          </View>
-        </View>
+        <OptionSheetHeader cover={album.cover} title={headerTitle} subtitle={headerSubtext} />
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <Text style={[styles.sectionLabel, { color: colors.subtext }]}>
-          {t('externalAlbum.download.chooseService')}
-        </Text>
+        <OptionSheetSectionLabel label={t('externalAlbum.download.chooseService')} />
 
         {available.map((downloader) => (
-          <TouchableOpacity
+          <OptionSheetRow
             key={downloader.def.id}
-            style={[styles.option, anyLoading && styles.optionDisabled]}
+            label={downloader.def.label}
+            description={t(downloader.def.descriptionKey)}
             onPress={() => handleDownload(downloader)}
             disabled={anyLoading}
-          >
-            <View style={styles.serviceText}>
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {downloader.def.label}
-              </Text>
-              <Text style={[styles.serviceDesc, { color: colors.subtext }]}>
-                {t(downloader.def.descriptionKey)}
-              </Text>
-            </View>
-            {loadingId === downloader.def.id
-              ? <SpinningLoaderCircle size={18} color={colors.subtext} />
-              : null}
-          </TouchableOpacity>
+            dimRow={anyLoading}
+            trailing={
+              loadingId === downloader.def.id
+                ? <SpinningLoaderCircle size={18} color={colors.subtext} />
+                : null
+            }
+          />
         ))}
       </BottomSheetScrollView>
     </BottomSheetModal>
@@ -125,53 +110,8 @@ const DownloadSheet: React.FC<Props> = ({ album, track, sheetRef }) => {
 export default DownloadSheet;
 
 const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
   content: {
     padding: 16,
     paddingBottom: 48,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '500' },
-  artist: { fontSize: 14, marginTop: 2 },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionDisabled: {
-    opacity: 0.55,
-  },
-  serviceText: {
-    flex: 1,
-  },
-  optionText: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  serviceDesc: {
-    fontSize: 13,
-    marginTop: 1,
   },
 });

--- a/src/components/options/ExternalAlbumOptions.tsx
+++ b/src/components/options/ExternalAlbumOptions.tsx
@@ -1,10 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-} from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
 import {
   BottomSheetModal,
@@ -17,10 +12,16 @@ import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import { useExternalAlbumStatus } from '@/hooks/useExternalAlbumStatus';
-import { MediaImage } from '@/components/MediaImage';
 import DownloadSheet from '@/components/options/DownloadSheet';
 import type { ExternalAlbumBase } from '@/types';
 import { useSheetRef } from '@/utils/useSheetRef';
+import {
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetRow,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 interface ExternalAlbumOptionsProps {
   album: ExternalAlbumBase;
@@ -28,7 +29,7 @@ interface ExternalAlbumOptionsProps {
 
 const ExternalAlbumOptions: React.FC<ExternalAlbumOptionsProps> = ({ album }) => {
   const { t } = useTranslation();
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
 
   const bottomSheetRef = useSheetRef();
   const downloadSheetRef = useSheetRef();
@@ -37,7 +38,7 @@ const ExternalAlbumOptions: React.FC<ExternalAlbumOptionsProps> = ({ album }) =>
   const status = useExternalAlbumStatus(album);
 
   const canDownload = useAnyDownloaderConnected();
-  const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
+  const sheetBg = useOptionSheetBackground();
 
   return (
     <>
@@ -55,55 +56,36 @@ const ExternalAlbumOptions: React.FC<ExternalAlbumOptionsProps> = ({ album }) =>
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       >
-        <BottomSheetView style={[styles.sheetContent, sheetBg]}>
-          <View style={styles.header}>
-            <MediaImage cover={album.cover} size="grid" style={styles.cover} />
-            <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={1}>
-                {album.title}
-              </Text>
-              <Text style={[styles.artist, { color: colors.subtext }]} numberOfLines={1}>
-                {album.artist}
-              </Text>
-            </View>
-          </View>
+        <BottomSheetView style={[optionSheetStyles.sheetContent, sheetBg]}>
+          <OptionSheetHeader cover={album.cover} title={album.title} subtitle={album.artist} />
 
-          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <OptionSheetDivider />
 
           {status.kind === 'in_library' ? (
-            <View style={styles.option}>
-              <Link size={26} color="#34C759" />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('externalAlbum.menu.inLibrary')}
-              </Text>
-            </View>
+            <OptionSheetRow
+              icon={<Link size={26} color="#34C759" />}
+              label={t('externalAlbum.menu.inLibrary')}
+            />
           ) : status.kind === 'downloading' ? (
-            <View style={styles.option}>
-              <SpinningLoaderCircle size={26} color="#007AFF" />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('externalAlbum.menu.downloading', { progress: status.progress })}
-              </Text>
-            </View>
+            <OptionSheetRow
+              icon={<SpinningLoaderCircle size={26} color="#007AFF" />}
+              label={t('externalAlbum.menu.downloading', { progress: status.progress })}
+            />
           ) : canDownload ? (
-            <TouchableOpacity
-              style={styles.option}
+            <OptionSheetRow
+              icon={<CloudDownload size={26} color={colors.secondary} />}
+              label={t('externalAlbum.menu.downloadToServer')}
               onPress={() => downloadSheetRef.current?.present()}
-            >
-              <CloudDownload size={26} color={colors.secondary} />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('externalAlbum.menu.downloadToServer')}
-              </Text>
-              <ChevronRight size={16} color={colors.placeholder} style={styles.chevron} />
-            </TouchableOpacity>
+              trailing={<ChevronRight size={16} color={colors.placeholder} style={styles.chevron} />}
+            />
           ) : (
-            <View style={styles.option}>
-              <CloudDownload size={26} color={colors.muted} />
-              <Text style={[styles.optionText, styles.disabledText]}>
-                {t('externalAlbum.menu.noServiceConnected')}
-              </Text>
-            </View>
+            <OptionSheetRow
+              icon={<CloudDownload size={26} color={colors.muted} />}
+              label={t('externalAlbum.menu.noServiceConnected')}
+              labelColor={colors.muted}
+            />
           )}
         </BottomSheetView>
       </BottomSheetModal>
@@ -119,37 +101,5 @@ const styles = StyleSheet.create({
   moreButton: {
     padding: 8,
   },
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '500' },
-  artist: { fontSize: 14, marginTop: 2 },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500', flex: 1 },
-  disabledText: { color: '#888', fontSize: 14 },
   chevron: { marginLeft: 4 },
 });

--- a/src/components/options/ExternalSongOptions.tsx
+++ b/src/components/options/ExternalSongOptions.tsx
@@ -1,10 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-} from 'react-native';
+import { TouchableOpacity, StyleSheet } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetScrollView,
@@ -18,12 +13,20 @@ import {
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
-import { MediaImage } from '@/components/MediaImage';
 import DownloadSheet from '@/components/options/DownloadSheet';
 import { ExternalSong } from '@/types';
 import type { ExternalAlbumBase } from '@/types';
 import { useSheetRef } from '@/utils/useSheetRef';
 import { formatSongDuration } from '@/utils/formatDuration';
+import {
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetInfoRow,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 interface ExternalSongOptionsProps {
   song: ExternalSong;
@@ -39,7 +42,7 @@ const ExternalSongOptions: React.FC<ExternalSongOptionsProps> = ({
   onPlay,
 }) => {
   const { t } = useTranslation();
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
 
   const bottomSheetRef = useSheetRef();
   const downloadSheetRef = useSheetRef();
@@ -49,7 +52,7 @@ const ExternalSongOptions: React.FC<ExternalSongOptionsProps> = ({
   const canDownload = useAnyDownloaderConnected();
   const canDownloadTrack = useAnyTrackDownloaderConnected();
 
-  const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
+  const sheetBg = useOptionSheetBackground();
 
   const albumBase = useMemo<ExternalAlbumBase>(() => ({
     id: song.albumId,
@@ -80,77 +83,57 @@ const ExternalSongOptions: React.FC<ExternalSongOptionsProps> = ({
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
         stackBehavior="push"
       >
         <BottomSheetScrollView
           style={sheetBg}
-          contentContainerStyle={styles.sheetContent}
+          contentContainerStyle={optionSheetStyles.sheetContent}
         >
-          <View style={styles.header}>
-            <MediaImage cover={song.cover} size="grid" style={styles.cover} />
-            <View style={styles.headerText}>
-              <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={1}>
-                {song.title}
-              </Text>
-              <Text style={[styles.artist, { color: colors.subtext }]} numberOfLines={1}>
-                {albumArtist} — {albumTitle}
-              </Text>
-            </View>
-          </View>
+          <OptionSheetHeader
+            cover={song.cover}
+            title={song.title}
+            subtitle={`${albumArtist} — ${albumTitle}`}
+          />
 
-          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <OptionSheetDivider />
 
           {onPlay && (
-            <TouchableOpacity
-              style={styles.option}
+            <OptionSheetRow
+              icon={<Play size={26} color={colors.secondary} fill={colors.secondary} />}
+              label={t('songOptions.actions.play')}
               onPress={() => {
                 bottomSheetRef.current?.dismiss();
                 onPlay();
               }}
-            >
-              <Play size={26} color={colors.secondary} fill={colors.secondary} />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('songOptions.actions.play')}
-              </Text>
-            </TouchableOpacity>
+            />
           )}
 
           {canDownloadTrack && (
-            <TouchableOpacity
-              style={styles.option}
+            <OptionSheetRow
+              icon={<Download size={26} color={colors.secondary} />}
+              label={t('externalAlbum.menu.downloadSong')}
               onPress={() => trackDownloadSheetRef.current?.present()}
-            >
-              <Download size={26} color={colors.secondary} />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('externalAlbum.menu.downloadSong')}
-              </Text>
-              <ChevronRight size={16} color={colors.placeholder} style={styles.chevron} />
-            </TouchableOpacity>
+              trailing={<ChevronRight size={16} color={colors.placeholder} style={styles.chevron} />}
+            />
           )}
 
           {canDownload && (
-            <TouchableOpacity
-              style={styles.option}
+            <OptionSheetRow
+              icon={<CloudDownload size={26} color={colors.secondary} />}
+              label={t('externalAlbum.menu.downloadToServer')}
               onPress={() => downloadSheetRef.current?.present()}
-            >
-              <CloudDownload size={26} color={colors.secondary} />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('externalAlbum.menu.downloadToServer')}
-              </Text>
-              <ChevronRight size={16} color={colors.placeholder} style={styles.chevron} />
-            </TouchableOpacity>
+              trailing={<ChevronRight size={16} color={colors.placeholder} style={styles.chevron} />}
+            />
           )}
 
-          {(!!onPlay || canDownload) && <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+          {(!!onPlay || canDownload) && <OptionSheetDivider />}
 
-          <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('songOptions.sections.media')}</Text>
-          <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.duration')}</Text>
-            <Text style={[styles.infoValue, { color: colors.secondary }]}>
-              {formatSongDuration(song.duration)}
-            </Text>
-          </View>
+          <OptionSheetSectionLabel label={t('songOptions.sections.media')} />
+          <OptionSheetInfoRow
+            label={t('songOptions.media.duration')}
+            value={formatSongDuration(song.duration)}
+          />
         </BottomSheetScrollView>
       </BottomSheetModal>
 
@@ -163,49 +146,5 @@ const ExternalSongOptions: React.FC<ExternalSongOptionsProps> = ({
 export default ExternalSongOptions;
 
 const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '500' },
-  artist: { fontSize: 14, marginTop: 2 },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500', flex: 1 },
   chevron: { marginLeft: 4 },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  infoRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-  },
-  infoLabel: { fontSize: 14 },
-  infoValue: { fontSize: 14, fontWeight: '500', marginLeft: 12, flex: 1, textAlign: 'right' },
 });

--- a/src/components/options/OptionSheetPrimitives.tsx
+++ b/src/components/options/OptionSheetPrimitives.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { MediaImage } from '@/components/MediaImage';
+import { useTheme } from '@/hooks/useTheme';
+import type { CoverSource } from '@/types';
+
+type HeaderProps = {
+  cover: CoverSource;
+  title: string;
+  subtitle?: string;
+  titleLines?: number;
+};
+
+export function OptionSheetHeader({ cover, title, subtitle, titleLines = 1 }: HeaderProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.header}>
+      <MediaImage cover={cover} size="grid" style={styles.cover} />
+      <View style={styles.headerText}>
+        <Text style={[styles.title, { color: colors.secondary }]} numberOfLines={titleLines}>
+          {title}
+        </Text>
+        {subtitle !== undefined && (
+          <Text style={[styles.subtitle, { color: colors.subtext }]} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+type RowProps = {
+  icon: React.ReactNode;
+  label: string;
+  onPress?: () => void;
+  /** Disables presses without changing appearance; pair with dimRow/dimLabel */
+  disabled?: boolean;
+  /** Fade the whole row (unavailable actions, e.g. while songs load) */
+  dimRow?: boolean;
+  /** Fade only the label (completed/in-flight actions, e.g. downloaded) */
+  dimLabel?: boolean;
+  /** Replace the icon with a spinner */
+  loading?: boolean;
+  labelColor?: string;
+  trailing?: React.ReactNode;
+};
+
+export function OptionSheetRow({
+  icon,
+  label,
+  onPress,
+  disabled,
+  dimRow,
+  dimLabel,
+  loading,
+  labelColor,
+  trailing,
+}: RowProps) {
+  const { colors } = useTheme();
+
+  return (
+    <TouchableOpacity
+      style={[styles.option, dimRow && styles.optionDimmed]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      {loading ? <ActivityIndicator size="small" color={colors.subtext} /> : icon}
+      <Text
+        style={[
+          styles.optionText,
+          { color: labelColor ?? colors.secondary },
+          dimLabel && styles.optionTextDimmed,
+        ]}
+      >
+        {label}
+      </Text>
+      {trailing}
+    </TouchableOpacity>
+  );
+}
+
+type InfoRowProps = {
+  label: string;
+  value: string | number;
+  valueLines?: number;
+};
+
+export function OptionSheetInfoRow({ label, value, valueLines }: InfoRowProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.infoRow}>
+      <Text style={[styles.infoLabel, { color: colors.subtext }]}>{label}</Text>
+      <Text style={[styles.infoValue, { color: colors.secondary }]} numberOfLines={valueLines}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+type SectionLabelProps = {
+  label: string;
+  /** Adds top margin when the label follows another section */
+  spaced?: boolean;
+};
+
+export function OptionSheetSectionLabel({ label, spaced }: SectionLabelProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Text style={[styles.sectionLabel, { color: colors.subtext }, spaced && styles.sectionLabelSpaced]}>
+      {label}
+    </Text>
+  );
+}
+
+export function OptionSheetDivider() {
+  const { colors } = useTheme();
+
+  return <View style={[styles.divider, { backgroundColor: colors.border }]} />;
+}
+
+type ChipsRowProps = {
+  label: string;
+  values: string[];
+};
+
+export function OptionSheetChipsRow({ label, values }: ChipsRowProps) {
+  const { isDarkMode, colors } = useTheme();
+  const chipBg = isDarkMode ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)';
+
+  return (
+    <View style={styles.chipsRow}>
+      <Text style={[styles.infoLabel, { color: colors.subtext }]}>{label}</Text>
+      <View style={styles.chipsList}>
+        {values.map((value, i) => (
+          <View key={`${value}-${i}`} style={[styles.chip, { backgroundColor: chipBg }]}>
+            <Text style={[styles.chipText, { color: colors.secondary }]}>{value}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/** Shared scaffold styles for BottomSheetModal-based option sheets */
+export const optionSheetStyles = StyleSheet.create({
+  sheetBackground: {
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  sheetContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 48,
+  },
+});
+
+/** Sheet surface color: elevated card in dark mode, plain background in light */
+export function useOptionSheetBackground() {
+  const { isDarkMode, colors } = useTheme();
+  return { backgroundColor: isDarkMode ? colors.card : colors.background };
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  cover: {
+    width: 48,
+    height: 48,
+    borderRadius: 6,
+    marginRight: 12,
+  },
+  headerText: { flex: 1 },
+  title: { fontSize: 16, fontWeight: '500' },
+  subtitle: { fontSize: 14, marginTop: 2 },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginVertical: 12,
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+  },
+  optionDimmed: {
+    opacity: 0.55,
+  },
+  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500', flex: 1 },
+  optionTextDimmed: {
+    opacity: 0.6,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '500',
+    marginBottom: 8,
+  },
+  sectionLabelSpaced: {
+    marginTop: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  infoLabel: { fontSize: 14 },
+  infoValue: { fontSize: 14, fontWeight: '500', marginLeft: 12, flex: 1, textAlign: 'right' },
+  chipsRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: 8,
+  },
+  chipsList: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginLeft: 12,
+    justifyContent: 'flex-end',
+    alignContent: 'flex-end',
+  },
+  chip: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+});

--- a/src/components/options/OptionSheetPrimitives.tsx
+++ b/src/components/options/OptionSheetPrimitives.tsx
@@ -38,8 +38,10 @@ export function OptionSheetHeader({ cover, title, subtitle, titleLines = 1 }: He
 }
 
 type RowProps = {
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
   label: string;
+  /** Optional second line under the label */
+  description?: string;
   onPress?: () => void;
   /** Disables presses without changing appearance; pair with dimRow/dimLabel */
   disabled?: boolean;
@@ -56,6 +58,7 @@ type RowProps = {
 export function OptionSheetRow({
   icon,
   label,
+  description,
   onPress,
   disabled,
   dimRow,
@@ -65,23 +68,29 @@ export function OptionSheetRow({
   trailing,
 }: RowProps) {
   const { colors } = useTheme();
+  const leading = loading ? <ActivityIndicator size="small" color={colors.subtext} /> : icon;
 
   return (
     <TouchableOpacity
       style={[styles.option, dimRow && styles.optionDimmed]}
       onPress={onPress}
-      disabled={disabled}
+      disabled={disabled || !onPress}
     >
-      {loading ? <ActivityIndicator size="small" color={colors.subtext} /> : icon}
-      <Text
-        style={[
-          styles.optionText,
-          { color: labelColor ?? colors.secondary },
-          dimLabel && styles.optionTextDimmed,
-        ]}
-      >
-        {label}
-      </Text>
+      {leading}
+      <View style={[styles.optionBody, !leading && styles.optionBodyNoIcon]}>
+        <Text
+          style={[
+            styles.optionText,
+            { color: labelColor ?? colors.secondary },
+            dimLabel && styles.optionTextDimmed,
+          ]}
+        >
+          {label}
+        </Text>
+        {description !== undefined && (
+          <Text style={[styles.optionDescription, { color: colors.subtext }]}>{description}</Text>
+        )}
+      </View>
       {trailing}
     </TouchableOpacity>
   );
@@ -201,9 +210,20 @@ const styles = StyleSheet.create({
   optionDimmed: {
     opacity: 0.55,
   },
-  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500', flex: 1 },
+  optionBody: {
+    flex: 1,
+    marginLeft: 16,
+  },
+  optionBodyNoIcon: {
+    marginLeft: 0,
+  },
+  optionText: { fontSize: 16, fontWeight: '500' },
   optionTextDimmed: {
     opacity: 0.6,
+  },
+  optionDescription: {
+    fontSize: 13,
+    marginTop: 1,
   },
   sectionLabel: {
     fontSize: 13,

--- a/src/components/options/PlaylistOptions.tsx
+++ b/src/components/options/PlaylistOptions.tsx
@@ -1,12 +1,5 @@
 import React, { forwardRef, useMemo, useState } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ActivityIndicator,
-  Alert,
-} from 'react-native';
+import { View, ActivityIndicator, Alert } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetScrollView,
@@ -15,7 +8,6 @@ import { ListEnd, Play, Shuffle, List, CheckCircle, ArrowDownCircle, Trash2, Pen
 import { toast } from '@backpackapp-io/react-native-toast';
 
 import { Playlist, PlaylistBase } from '@/types';
-import { MediaImage } from '@/components/MediaImage';
 import { usePlaying } from '@/contexts/PlayingContext';
 import { useDownload } from '@/contexts/DownloadContext';
 import { useNavigation } from '@react-navigation/native';
@@ -26,6 +18,15 @@ import { FAVORITES_ID } from '@/constants/favorites';
 import { useTranslation } from 'react-i18next';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import { useLazyPlaylistDetail } from './useLazyCollectionDetails';
+import {
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetInfoRow,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 export type PlaylistOptionsProps = {
   playlist: PlaylistBase | Playlist | null;
@@ -48,7 +49,7 @@ const PlaylistOptions = forwardRef<
   PlaylistOptionsProps
 >(({ playlist, hideGoToPlaylist }, ref) => {
   const { t } = useTranslation();
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
   const navigation = useNavigation<any>();
   const router = useRouter();
 
@@ -69,7 +70,7 @@ const PlaylistOptions = forwardRef<
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const { playlistWithSongs, songs, songsLoading } = useLazyPlaylistDetail(playlist, isSheetOpen);
 
-  const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
+  const sheetBg = useOptionSheetBackground();
 
   const close = () => {
     (ref as any)?.current?.dismiss();
@@ -175,9 +176,9 @@ const PlaylistOptions = forwardRef<
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       >
-        <View style={[styles.loading, sheetBg]}>
+        <View style={[optionSheetStyles.loading, sheetBg]}>
           <ActivityIndicator size="large" color={colors.subtext} />
         </View>
       </BottomSheetModal>
@@ -192,150 +193,108 @@ const PlaylistOptions = forwardRef<
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       handleIndicatorStyle={{ backgroundColor: colors.border }}
-      backgroundStyle={[styles.sheetBackground, sheetBg]}
+      backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
       stackBehavior="push"
       onChange={(index) => setIsSheetOpen(index >= 0)}
     >
       <BottomSheetScrollView
         style={sheetBg}
-        contentContainerStyle={styles.sheetContent}
+        contentContainerStyle={optionSheetStyles.sheetContent}
       >
-        <View style={styles.header}>
-          <MediaImage cover={playlist.cover} size="grid" style={styles.cover} />
-          <View style={styles.headerText}>
-            <Text
-              style={[styles.title, { color: colors.secondary }]}
-              numberOfLines={2}
-            >
-              {playlist.title}
-            </Text>
-            <Text style={[styles.artist, { color: colors.subtext }]}>{t('playlistOptions.playlistLabel')}</Text>
-          </View>
-        </View>
+        <OptionSheetHeader
+          cover={playlist.cover}
+          title={playlist.title}
+          subtitle={t('playlistOptions.playlistLabel')}
+          titleLines={2}
+        />
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+        <OptionSheetRow
+          icon={<Play size={26} color={colors.secondary} fill={colors.secondary} />}
+          label={t('playlistOptions.actions.play')}
           onPress={() => handlePlay(false)}
           disabled={playbackDisabled}
-        >
-          {songsLoading ? (
-            <ActivityIndicator size="small" color={colors.subtext} />
-          ) : (
-            <Play size={26} color={colors.secondary} fill={colors.secondary} />
-          )}
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('playlistOptions.actions.play')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+          loading={songsLoading}
+        />
+        <OptionSheetRow
+          icon={<Shuffle size={26} color={colors.secondary} />}
+          label={t('playlistOptions.actions.shuffle')}
           onPress={() => handlePlay(true)}
           disabled={playbackDisabled}
-        >
-          <Shuffle size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('playlistOptions.actions.shuffle')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<ListEnd size={26} color={colors.secondary} />}
+          label={t('playlistOptions.actions.addToQueue')}
           onPress={handleAddToQueue}
           disabled={playbackDisabled}
-        >
-          <ListEnd size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('playlistOptions.actions.addToQueue')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.option, playbackDisabled && styles.optionDisabled]}
+          dimRow={playbackDisabled}
+        />
+        <OptionSheetRow
+          icon={<Shuffle size={26} color={colors.secondary} />}
+          label={t('playlistOptions.actions.shuffleToQueue')}
           onPress={handleShuffleToQueue}
           disabled={playbackDisabled}
-        >
-          <Shuffle size={26} color={colors.secondary} />
-          <Text style={[styles.optionText, { color: colors.secondary }]}>{t('playlistOptions.actions.shuffleToQueue')}</Text>
-        </TouchableOpacity>
+          dimRow={playbackDisabled}
+        />
 
         {!hideGoToPlaylist && (
-          <TouchableOpacity style={styles.option} onPress={handleGoToPlaylist}>
-            <List size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>{t('playlistOptions.actions.goToPlaylist')}</Text>
-          </TouchableOpacity>
+          <OptionSheetRow
+            icon={<List size={26} color={colors.secondary} />}
+            label={t('playlistOptions.actions.goToPlaylist')}
+            onPress={handleGoToPlaylist}
+          />
         )}
 
-        <TouchableOpacity
-          style={styles.option}
+        <OptionSheetRow
+          icon={
+            isDownloaded ? (
+              <CheckCircle size={26} color={colors.subtext} />
+            ) : (
+              <ArrowDownCircle size={26} color={colors.secondary} />
+            )
+          }
+          label={isDownloading ? t('playlistOptions.actions.downloading') : isDownloaded ? t('playlistOptions.actions.downloaded') : t('playlistOptions.actions.download')}
           onPress={handleDownload}
           disabled={isDownloaded || isDownloading}
-        >
-          {isDownloading ? (
-            <ActivityIndicator size="small" color={colors.subtext} />
-          ) : isDownloaded ? (
-            <CheckCircle size={26} color={colors.subtext} />
-          ) : (
-            <ArrowDownCircle size={26} color={colors.secondary} />
-          )}
-          <Text
-            style={[
-              styles.optionText,
-              { color: colors.secondary },
-              (isDownloaded || isDownloading) && { opacity: 0.6 },
-            ]}
-          >
-            {isDownloading ? t('playlistOptions.actions.downloading') : isDownloaded ? t('playlistOptions.actions.downloaded') : t('playlistOptions.actions.download')}
-          </Text>
-        </TouchableOpacity>
+          loading={isDownloading}
+          dimLabel={isDownloaded || isDownloading}
+        />
 
         {playlist.id !== FAVORITES_ID && (
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<Pencil size={26} color={colors.secondary} />}
+            label={t('playlistOptions.actions.rename')}
             onPress={handleRenamePress}
-          >
-            <Pencil size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>
-              {t('playlistOptions.actions.rename')}
-            </Text>
-          </TouchableOpacity>
+          />
         )}
 
         {playlist.id !== FAVORITES_ID && (
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<Trash2 size={26} color="#ff3b30" />}
+            label={t('playlistOptions.actions.delete')}
+            labelColor="#ff3b30"
             onPress={handleDeletePress}
             disabled={deletePlaylist.isPending}
-          >
-            {deletePlaylist.isPending ? (
-              <ActivityIndicator size="small" color={colors.subtext} />
-            ) : (
-              <Trash2 size={26} color="#ff3b30" />
-            )}
-            <Text
-              style={[
-                styles.optionText,
-                { color: '#ff3b30' },
-                deletePlaylist.isPending && { opacity: 0.6 },
-              ]}
-            >
-              {t('playlistOptions.actions.delete')}
-            </Text>
-          </TouchableOpacity>
+            loading={deletePlaylist.isPending}
+            dimLabel={deletePlaylist.isPending}
+          />
         )}
 
-        <View style={[styles.divider, { backgroundColor: colors.border }]} />
+        <OptionSheetDivider />
 
-        <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('playlistOptions.sections.info')}</Text>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('playlistOptions.info.lastChanged')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>
-            {formatDate(playlist.changed)}
-          </Text>
-        </View>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('playlistOptions.info.created')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>
-            {formatDate(playlist.created)}
-          </Text>
-        </View>
-        <View style={styles.infoRow}>
-          <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('playlistOptions.info.songs')}</Text>
-          <Text style={[styles.infoValue, { color: colors.secondary }]}>{songs.length}</Text>
-        </View>
+        <OptionSheetSectionLabel label={t('playlistOptions.sections.info')} />
+        <OptionSheetInfoRow
+          label={t('playlistOptions.info.lastChanged')}
+          value={formatDate(playlist.changed)}
+        />
+        <OptionSheetInfoRow
+          label={t('playlistOptions.info.created')}
+          value={formatDate(playlist.created)}
+        />
+        <OptionSheetInfoRow label={t('playlistOptions.info.songs')} value={songs.length} />
       </BottomSheetScrollView>
     </BottomSheetModal>
   );
@@ -344,59 +303,3 @@ const PlaylistOptions = forwardRef<
 PlaylistOptions.displayName = 'PlaylistOptions';
 
 export default PlaylistOptions;
-
-const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
-  loading: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 48,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: { flex: 1 },
-  title: { fontSize: 16, fontWeight: '500' },
-  artist: { fontSize: 14, marginTop: 2 },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionDisabled: {
-    opacity: 0.55,
-  },
-  optionText: { marginLeft: 16, fontSize: 16, fontWeight: '500' },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  infoRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-  },
-  infoLabel: { fontSize: 14 },
-  infoValue: { fontSize: 14, fontWeight: '500', marginLeft: 12, flex: 1, textAlign: 'right' },
-});

--- a/src/components/options/SongOptions.tsx
+++ b/src/components/options/SongOptions.tsx
@@ -1,12 +1,5 @@
 import React, { forwardRef, useMemo, useRef } from 'react';
-import {
-  Alert,
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  ActivityIndicator,
-} from 'react-native';
+import { Alert } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetScrollView,
@@ -17,7 +10,6 @@ import { Song } from '@/types';
 import { usePlayingState, usePlayingActions } from '@/contexts/PlayingContext';
 import { useSelector } from 'react-redux';
 import { selectSongPlayCount } from '@/utils/redux/selectors/statsSelectors';
-import { MediaImage } from '@/components/MediaImage';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { useTheme } from '@/hooks/useTheme';
 import { useRouter } from 'expo-router';
@@ -27,6 +19,16 @@ import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import { useIsOffline } from '@/hooks/useIsOffline';
 import { formatSongDuration } from '@/utils/formatDuration';
 import { useDownload } from '@/contexts/DownloadContext';
+import {
+  OptionSheetChipsRow,
+  OptionSheetDivider,
+  OptionSheetHeader,
+  OptionSheetInfoRow,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from './OptionSheetPrimitives';
 
 type SongOptionsProps = {
   selectedSong: Song;
@@ -50,7 +52,7 @@ const SongOptions = forwardRef<
   SongOptionsProps
 >(({ selectedSong, onAddToPlaylist, onNavigate }, ref) => {
     const { t } = useTranslation();
-    const { isDarkMode, colors } = useTheme();
+    const { colors } = useTheme();
     const isOffline = useIsOffline();
 
     const snapPoints = useMemo(() => ['55%', '90%'], []);
@@ -73,7 +75,7 @@ const SongOptions = forwardRef<
     const isDownloaded = isTrackDownloaded(selectedSong.id);
     const isDownloading = isTrackDownloading(selectedSong.id);
 
-    const sheetBg = { backgroundColor: isDarkMode ? colors.card : colors.background };
+    const sheetBg = useOptionSheetBackground();
 
     const close = () => {
       (ref as any)?.current?.dismiss();
@@ -211,10 +213,6 @@ const SongOptions = forwardRef<
       }
     };
 
-    const genreChipBg = isDarkMode
-      ? 'rgba(255,255,255,0.12)'
-      : 'rgba(0,0,0,0.08)';
-
     return (
       <BottomSheetModal
         ref={ref}
@@ -223,237 +221,163 @@ const SongOptions = forwardRef<
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={{ backgroundColor: colors.border }}
-        backgroundStyle={[styles.sheetBackground, sheetBg]}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
         stackBehavior='push'
       >
         <BottomSheetScrollView
           testID="song-options-sheet"
           style={sheetBg}
-          contentContainerStyle={styles.sheetContent}
+          contentContainerStyle={optionSheetStyles.sheetContent}
         >
-          <View style={styles.header}>
-            <MediaImage
-              cover={selectedSong.cover}
-              size="grid"
-              style={styles.cover}
-            />
-            <View style={styles.headerText}>
-              <Text
-                style={[styles.title, { color: colors.secondary }]}
-                numberOfLines={1}
-              >
-                {selectedSong.title}
-              </Text>
-              <Text
-                style={[styles.artist, { color: colors.subtext }]}
-                numberOfLines={1}
-              >
-                {selectedSong.artist || t('songOptions.unknownArtist')}
-              </Text>
-            </View>
-          </View>
+          <OptionSheetHeader
+            cover={selectedSong.cover}
+            title={selectedSong.title}
+            subtitle={selectedSong.artist || t('songOptions.unknownArtist')}
+          />
 
-          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <OptionSheetDivider />
 
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<Heart size={26} color="#ff3b30" fill={isStarred ? '#ff3b30' : 'none'} />}
+            label={isStarred ? t('songOptions.actions.unfavorite') : t('songOptions.actions.favorite')}
             onPress={toggleFavorite}
-          >
-            <Heart size={26} color="#ff3b30" fill={isStarred ? '#ff3b30' : 'none'} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>
-              {isStarred ? t('songOptions.actions.unfavorite') : t('songOptions.actions.favorite')}
-            </Text>
-          </TouchableOpacity>
+          />
 
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<ListStart size={26} color={colors.secondary} />}
+            label={t('songOptions.actions.addToQueue')}
             onPress={handleAddToQueue}
-          >
-            <ListStart size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>
-              {t('songOptions.actions.addToQueue')}
-            </Text>
-          </TouchableOpacity>
+          />
 
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<ListEnd size={26} color={colors.secondary} />}
+            label={t('songOptions.actions.addToEnd')}
             onPress={handleAddToEndQueue}
-          >
-            <ListEnd size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>
-              {t('songOptions.actions.addToEnd')}
-            </Text>
-          </TouchableOpacity>
+          />
 
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<CirclePlus size={26} color={colors.secondary} />}
+            label={t('songOptions.actions.addToPlaylist')}
             onPress={handleAddToPlaylist}
-          >
-            <CirclePlus size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>
-              {t('songOptions.actions.addToPlaylist')}
-            </Text>
-          </TouchableOpacity>
+          />
 
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={
+              isDownloaded ? (
+                <CheckCircle size={26} color={colors.subtext} />
+              ) : (
+                <ArrowDownCircle size={26} color={colors.secondary} />
+              )
+            }
+            label={isDownloading ? t('songOptions.actions.downloading') : isDownloaded ? t('songOptions.actions.downloaded') : t('songOptions.actions.download')}
             onPress={handleDownload}
             disabled={isDownloading}
-          >
-            {isDownloading ? (
-              <ActivityIndicator size="small" color={colors.subtext} />
-            ) : isDownloaded ? (
-              <CheckCircle size={26} color={colors.subtext} />
-            ) : (
-              <ArrowDownCircle size={26} color={colors.secondary} />
-            )}
-            <Text
-              style={[
-                styles.optionText,
-                { color: colors.secondary },
-                (isDownloaded || isDownloading) && { opacity: 0.6 },
-              ]}
-            >
-              {isDownloading ? t('songOptions.actions.downloading') : isDownloaded ? t('songOptions.actions.downloaded') : t('songOptions.actions.download')}
-            </Text>
-          </TouchableOpacity>
+            loading={isDownloading}
+            dimLabel={isDownloaded || isDownloading}
+          />
 
           {selectedSong.albumId && (
-            <TouchableOpacity
-              style={styles.option}
+            <OptionSheetRow
+              icon={<Disc size={26} color={colors.secondary} />}
+              label={t('songOptions.actions.goToAlbum')}
               onPress={handleGoToAlbum}
-            >
-              <Disc size={26} color={colors.secondary} />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('songOptions.actions.goToAlbum')}
-              </Text>
-            </TouchableOpacity>
+            />
           )}
 
           {selectedSong.artistId && (
-            <TouchableOpacity
-              style={styles.option}
+            <OptionSheetRow
+              icon={<Mic2 size={26} color={colors.secondary} />}
+              label={t('songOptions.actions.goToArtist')}
               onPress={handleGoToArtist}
-            >
-              <Mic2 size={26} color={colors.secondary} />
-              <Text style={[styles.optionText, { color: colors.secondary }]}>
-                {t('songOptions.actions.goToArtist')}
-              </Text>
-            </TouchableOpacity>
+            />
           )}
 
-          <TouchableOpacity
-            style={styles.option}
+          <OptionSheetRow
+            icon={<Radio size={26} color={colors.secondary} />}
+            label={t('songOptions.actions.instantMix')}
             onPress={handleInstantMix}
-          >
-            <Radio size={26} color={colors.secondary} />
-            <Text style={[styles.optionText, { color: colors.secondary }]}>
-              {t('songOptions.actions.instantMix')}
-            </Text>
-          </TouchableOpacity>
+          />
 
-          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <OptionSheetDivider />
 
-          <Text style={[styles.sectionLabel, { color: colors.subtext }]}>{t('songOptions.sections.media')}</Text>
-          <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.duration')}</Text>
-            <Text style={[styles.infoValue, { color: colors.secondary }]}>
-              {formatSongDuration(selectedSong.duration)}
-            </Text>
-          </View>
-          <View style={styles.infoRow}>
-            <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.plays')}</Text>
-            <Text style={[styles.infoValue, { color: colors.secondary }]}>{playCount}</Text>
-          </View>
+          <OptionSheetSectionLabel label={t('songOptions.sections.media')} />
+          <OptionSheetInfoRow
+            label={t('songOptions.media.duration')}
+            value={formatSongDuration(selectedSong.duration)}
+          />
+          <OptionSheetInfoRow label={t('songOptions.media.plays')} value={playCount} />
           {selectedSong.bitrate != null && (
-            <View style={styles.infoRow}>
-              <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.bitrate')}</Text>
-              <Text style={[styles.infoValue, { color: colors.secondary }]}>{t('songOptions.media.kbps', { value: selectedSong.bitrate })}</Text>
-            </View>
+            <OptionSheetInfoRow
+              label={t('songOptions.media.bitrate')}
+              value={t('songOptions.media.kbps', { value: selectedSong.bitrate })}
+            />
           )}
           {selectedSong.sampleRate != null && (
-            <View style={styles.infoRow}>
-              <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.sampleRate')}</Text>
-              <Text style={[styles.infoValue, { color: colors.secondary }]}>{t('songOptions.media.hz', { value: selectedSong.sampleRate })}</Text>
-            </View>
+            <OptionSheetInfoRow
+              label={t('songOptions.media.sampleRate')}
+              value={t('songOptions.media.hz', { value: selectedSong.sampleRate })}
+            />
           )}
           {selectedSong.bitsPerSample != null && (
-            <View style={styles.infoRow}>
-              <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.bitsPerSample')}</Text>
-              <Text style={[styles.infoValue, { color: colors.secondary }]}>{selectedSong.bitsPerSample}</Text>
-            </View>
+            <OptionSheetInfoRow
+              label={t('songOptions.media.bitsPerSample')}
+              value={selectedSong.bitsPerSample}
+            />
           )}
           {selectedSong.mimeType && (
-            <View style={styles.infoRow}>
-              <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.media.format')}</Text>
-              <Text style={[styles.infoValue, { color: colors.secondary }]} numberOfLines={1}>{selectedSong.mimeType}</Text>
-            </View>
+            <OptionSheetInfoRow
+              label={t('songOptions.media.format')}
+              value={selectedSong.mimeType}
+              valueLines={1}
+            />
           )}
 
           {(selectedSong.disc != null || selectedSong.trackNumber != null) && (
             <>
-              <Text style={[styles.sectionLabel, { color: colors.subtext }, styles.sectionLabelSpaced]}>{t('songOptions.sections.track')}</Text>
+              <OptionSheetSectionLabel label={t('songOptions.sections.track')} spaced />
               {selectedSong.disc != null && (
-                <View style={styles.infoRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.track.disc')}</Text>
-                  <Text style={[styles.infoValue, { color: colors.secondary }]}>{selectedSong.disc}</Text>
-                </View>
+                <OptionSheetInfoRow label={t('songOptions.track.disc')} value={selectedSong.disc} />
               )}
               {selectedSong.trackNumber != null && (
-                <View style={styles.infoRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.track.track')}</Text>
-                  <Text style={[styles.infoValue, { color: colors.secondary }]}>{selectedSong.trackNumber}</Text>
-                </View>
+                <OptionSheetInfoRow label={t('songOptions.track.track')} value={selectedSong.trackNumber} />
               )}
             </>
           )}
 
           {(selectedSong.dateReleased || selectedSong.dateAdded) && (
             <>
-              <Text style={[styles.sectionLabel, { color: colors.subtext }, styles.sectionLabelSpaced]}>{t('songOptions.sections.dates')}</Text>
+              <OptionSheetSectionLabel label={t('songOptions.sections.dates')} spaced />
               {selectedSong.dateReleased && (
-                <View style={styles.infoRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.dates.released')}</Text>
-                  <Text style={[styles.infoValue, { color: colors.secondary }]}>{formatDate(selectedSong.dateReleased)}</Text>
-                </View>
+                <OptionSheetInfoRow
+                  label={t('songOptions.dates.released')}
+                  value={formatDate(selectedSong.dateReleased)}
+                />
               )}
               {selectedSong.dateAdded && (
-                <View style={styles.infoRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.dates.added')}</Text>
-                  <Text style={[styles.infoValue, { color: colors.secondary }]} numberOfLines={1}>{formatDate(selectedSong.dateAdded)}</Text>
-                </View>
+                <OptionSheetInfoRow
+                  label={t('songOptions.dates.added')}
+                  value={formatDate(selectedSong.dateAdded)}
+                  valueLines={1}
+                />
               )}
             </>
           )}
 
           {(selectedSong.bpm != null || selectedSong.genres?.length || selectedSong.filePath) && (
             <>
-              <Text style={[styles.sectionLabel, { color: colors.subtext }, styles.sectionLabelSpaced]}>{t('songOptions.sections.other')}</Text>
+              <OptionSheetSectionLabel label={t('songOptions.sections.other')} spaced />
               {selectedSong.bpm != null && (
-                <View style={styles.infoRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.other.bpm')}</Text>
-                  <Text style={[styles.infoValue, { color: colors.secondary }]}>{selectedSong.bpm}</Text>
-                </View>
+                <OptionSheetInfoRow label={t('songOptions.other.bpm')} value={selectedSong.bpm} />
               )}
               {selectedSong.genres?.length ? (
-                <View style={styles.genreRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.other.genres')}</Text>
-                  <View style={styles.genreList}>
-                    {selectedSong.genres.map((g, i) => (
-                      <View key={`${g}-${i}`} style={[styles.genreChip, { backgroundColor: genreChipBg }]}>
-                        <Text style={[styles.genreChipText, { color: colors.secondary }]}>{g}</Text>
-                      </View>
-                    ))}
-                  </View>
-                </View>
+                <OptionSheetChipsRow label={t('songOptions.other.genres')} values={selectedSong.genres} />
               ) : null}
               {selectedSong.filePath ? (
-                <View style={styles.infoRow}>
-                  <Text style={[styles.infoLabel, { color: colors.subtext }]}>{t('songOptions.other.filePath')}</Text>
-                  <Text style={[styles.infoValue, { color: colors.secondary }]} numberOfLines={2}>
-                    {selectedSong.filePath}
-                  </Text>
-                </View>
+                <OptionSheetInfoRow
+                  label={t('songOptions.other.filePath')}
+                  value={selectedSong.filePath}
+                  valueLines={2}
+                />
               ) : null}
             </>
           )}
@@ -466,87 +390,3 @@ const SongOptions = forwardRef<
 SongOptions.displayName = 'SongOptions';
 
 export default SongOptions;
-
-const styles = StyleSheet.create({
-  sheetBackground: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-  },
-  sheetContent: {
-    padding: 16,
-    paddingBottom: 32,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  cover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  headerText: {
-    flex: 1,
-  },
-  title: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  artist: {
-    fontSize: 14,
-    marginTop: 2,
-  },
-  divider: {
-    height: StyleSheet.hairlineWidth,
-    marginVertical: 12,
-  },
-  option: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 14,
-  },
-  optionText: {
-    marginLeft: 16,
-    fontSize: 16,
-  },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '500',
-    marginBottom: 8,
-  },
-  sectionLabelSpaced: {
-    marginTop: 16,
-  },
-  infoRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-  },
-  infoLabel: { fontSize: 14 },
-  infoValue: { fontSize: 14, fontWeight: '500', marginLeft: 12, flex: 1, textAlign: 'right' },
-  genreRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    paddingVertical: 8,
-  },
-  genreList: {
-    flex: 1,
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-    marginLeft: 12,
-    justifyContent: 'flex-end',
-    alignContent: 'flex-end',
-  },
-  genreChip: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 12,
-  },
-  genreChipText: {
-    fontSize: 13,
-    fontWeight: '500',
-  },
-});


### PR DESCRIPTION
Follow-up to #162/#163, extending the design system to the bottom-sheet option menus. All seven option sheets now share one set of primitives.

## What changed
- New `src/components/options/OptionSheetPrimitives.tsx` with the shared building blocks all option sheets duplicated:
  - `OptionSheetHeader` — cover + title/subtitle header
  - `OptionSheetRow` — action row with optional `icon`, optional `description` second line, `disabled` / `dimRow` (0.55 row fade for unavailable actions) / `dimLabel` (0.6 label fade for downloaded/in-flight states) / `loading` spinner / `trailing` slot; auto-disables presses when no `onPress` so static status rows don't flash
  - `OptionSheetInfoRow`, `OptionSheetSectionLabel`, `OptionSheetDivider`, `OptionSheetChipsRow` (genre chips)
  - `optionSheetStyles` + `useOptionSheetBackground()` for the shared modal scaffold (radius, content padding, dark-mode card surface)
- Migrated all sheets: `SongOptions`, `AlbumOptions`, `ArtistOptions`, `PlaylistOptions`, `ExternalSongOptions`, `ExternalAlbumOptions`, `DownloadSheet`. Net −364 lines with the new primitives included.

## Behavior preserved
- All i18n keys, snap points, `stackBehavior`, `onChange` lazy-load wiring, testIDs, and disabled/loading states unchanged.
- Two deliberate visual unifications, both toward the majority style:
  - SongOptions action labels were the only ones at 400 weight; now 500 like every other sheet.
  - ExternalAlbumOptions "no service connected" label was a one-off 14pt `#888`; now the standard 16pt row label in `colors.muted`.

## Validation
- `npx tsc --noEmit`
- `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wi7RSs3KhyDvTp9ReHBmb