### PR TITLE
Migrate external rows onto MediaListRow

### DIFF
--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -26,7 +26,6 @@ type Props = {
   roundedCover?: boolean;
   showCover?: boolean;
   variant?: 'default' | 'compact';
-  contentStyle?: StyleProp<ViewStyle>;
   rowStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
 };
@@ -43,7 +42,6 @@ export default function MediaListRow({
   roundedCover,
   showCover = true,
   variant = 'default',
-  contentStyle,
   rowStyle,
   style,
 }: Props) {
@@ -54,7 +52,7 @@ export default function MediaListRow({
     <View style={[styles.wrapper, style]}>
       <View style={[styles.row, isCompact && styles.compactRow, rowStyle]}>
         <TouchableOpacity
-          style={[styles.content, contentStyle]}
+          style={styles.content}
           onPress={onPress}
           disabled={disabled || !onPress}
           activeOpacity={disabled ? 1 : 0.7}
@@ -111,6 +109,7 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
+    gap: spacing.rowGap,
     marginBottom: 16,
   },
   compactRow: {

--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -18,7 +18,11 @@ type Props = {
   cover: CoverSource;
   onPress?: () => void;
   disabled?: boolean;
+  /** Rendered inside the touchable before the cover, e.g. a track index */
+  leading?: React.ReactNode;
   trailing?: React.ReactNode;
+  /** Rendered on the subtitle line after the text, e.g. status badges */
+  subtitleTrailing?: React.ReactNode;
   roundedCover?: boolean;
   showCover?: boolean;
   variant?: 'default' | 'compact';
@@ -33,7 +37,9 @@ export default function MediaListRow({
   cover,
   onPress,
   disabled,
+  leading,
   trailing,
+  subtitleTrailing,
   roundedCover,
   showCover = true,
   variant = 'default',
@@ -53,6 +59,7 @@ export default function MediaListRow({
           disabled={disabled || !onPress}
           activeOpacity={disabled ? 1 : 0.7}
         >
+          {leading}
           {showCover && (
             <MediaImage
               cover={cover}
@@ -74,12 +81,28 @@ export default function MediaListRow({
             </Text>
 
             {subtitle !== undefined && (
-              <Text
-                numberOfLines={1}
-                style={[isCompact ? styles.compactSubtitle : styles.subtitle, { color: colors.subtext }]}
-              >
-                {subtitle}
-              </Text>
+              subtitleTrailing ? (
+                <View style={[styles.subtitleRow, isCompact ? styles.compactSubtitleSpacing : styles.subtitleSpacing]}>
+                  <Text
+                    numberOfLines={1}
+                    style={[
+                      isCompact ? styles.compactSubtitleText : styles.subtitleText,
+                      styles.subtitleFlex,
+                      { color: colors.subtext },
+                    ]}
+                  >
+                    {subtitle}
+                  </Text>
+                  {subtitleTrailing}
+                </View>
+              ) : (
+                <Text
+                  numberOfLines={1}
+                  style={[isCompact ? styles.compactSubtitle : styles.subtitle, { color: colors.subtext }]}
+                >
+                  {subtitle}
+                </Text>
+              )
             )}
           </View>
         </TouchableOpacity>
@@ -139,5 +162,21 @@ const styles = StyleSheet.create({
   compactSubtitle: {
     ...typography.compactRowSubtitle,
     marginTop: 1,
+  },
+  subtitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  subtitleSpacing: {
+    marginTop: 2,
+  },
+  compactSubtitleSpacing: {
+    marginTop: 1,
+  },
+  subtitleText: typography.rowSubtitle,
+  compactSubtitleText: typography.compactRowSubtitle,
+  subtitleFlex: {
+    flex: 1,
   },
 });

--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -81,28 +81,19 @@ export default function MediaListRow({
             </Text>
 
             {subtitle !== undefined && (
-              subtitleTrailing ? (
-                <View style={[styles.subtitleRow, isCompact ? styles.compactSubtitleSpacing : styles.subtitleSpacing]}>
-                  <Text
-                    numberOfLines={1}
-                    style={[
-                      isCompact ? styles.compactSubtitleText : styles.subtitleText,
-                      styles.subtitleFlex,
-                      { color: colors.subtext },
-                    ]}
-                  >
-                    {subtitle}
-                  </Text>
-                  {subtitleTrailing}
-                </View>
-              ) : (
+              <View style={[styles.subtitleRow, isCompact ? styles.compactSubtitleSpacing : styles.subtitleSpacing]}>
                 <Text
                   numberOfLines={1}
-                  style={[isCompact ? styles.compactSubtitle : styles.subtitle, { color: colors.subtext }]}
+                  style={[
+                    isCompact ? styles.compactSubtitleText : styles.subtitleText,
+                    styles.subtitleFlex,
+                    { color: colors.subtext },
+                  ]}
                 >
                   {subtitle}
                 </Text>
-              )
+                {subtitleTrailing}
+              </View>
             )}
           </View>
         </TouchableOpacity>
@@ -155,14 +146,6 @@ const styles = StyleSheet.create({
   },
   title: typography.rowTitle,
   compactTitle: typography.compactRowTitle,
-  subtitle: {
-    ...typography.rowSubtitle,
-    marginTop: 2,
-  },
-  compactSubtitle: {
-    ...typography.compactRowSubtitle,
-    marginTop: 1,
-  },
   subtitleRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/components/rows/ExternalAlbumRow/index.tsx
+++ b/src/components/rows/ExternalAlbumRow/index.tsx
@@ -14,7 +14,6 @@ import { useExternalAlbumStatus } from '@/hooks/useExternalAlbumStatus';
 
 type Props = {
   album: ExternalAlbumBase;
-  artistName: string;
   onPress?: (album: ExternalAlbumBase) => void;
   /** Show a "not in your library" glyph for the common case (status.kind === 'none').
    * Only meaningful where local and external rows can appear side by side in
@@ -26,7 +25,7 @@ type Props = {
   subtextOverride?: string;
 };
 
-const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExternalBadge, subtextOverride }) => {
+const ExternalAlbumRow: React.FC<Props> = ({ album, onPress, showExternalBadge, subtextOverride }) => {
   const { colors } = useTheme();
   const status = useExternalAlbumStatus(album);
 

--- a/src/components/rows/ExternalAlbumRow/index.tsx
+++ b/src/components/rows/ExternalAlbumRow/index.tsx
@@ -3,13 +3,12 @@ import {
   View,
   Text,
   StyleSheet,
-  TouchableOpacity,
 } from 'react-native';
 import { Link, ArrowDownCircle, Cloud } from 'lucide-react-native';
 
 import { ExternalAlbumBase } from '@/types';
 import ExternalAlbumOptions from '@/components/options/ExternalAlbumOptions';
-import { MediaImage } from '@/components/MediaImage';
+import MediaListRow from '@/components/MediaListRow';
 import { useTheme } from '@/hooks/useTheme';
 import { useExternalAlbumStatus } from '@/hooks/useExternalAlbumStatus';
 
@@ -33,94 +32,33 @@ const ExternalAlbumRow: React.FC<Props> = ({ album, artistName, onPress, showExt
 
   const handlePress = useCallback(() => onPress?.(album), [onPress, album]);
 
-  return (
-    <View style={styles.wrapper}>
-      <View style={styles.albumItem}>
-        <TouchableOpacity
-          style={styles.albumContent}
-          onPress={handlePress}
-        >
-          <MediaImage cover={album.cover} size="thumb" style={styles.cover} />
-
-          <View style={styles.albumTextContainer}>
-            <Text
-              numberOfLines={1}
-              style={[styles.albumTitle, { color: colors.secondary }]}
-            >
-              {album.title}
-            </Text>
-
-            <View style={styles.subtextRow}>
-              <Text
-                numberOfLines={1}
-                style={[styles.albumSubtext, { color: colors.subtext }, styles.subtextFlex]}
-              >
-                {subtextOverride ?? album.subtext}
-              </Text>
-
-              {status.kind === 'in_library' && (
-                <Link size={14} color="#34C759" />
-              )}
-              {status.kind === 'downloading' && (
-                <View style={styles.badge}>
-                  <ArrowDownCircle size={12} color="#007AFF" />
-                  <Text style={[styles.badgeText, styles.badgeTextBlue]}>{status.progress}%</Text>
-                </View>
-              )}
-              {status.kind === 'none' && showExternalBadge && (
-                <Cloud size={14} color={colors.subtext} />
-              )}
-            </View>
-          </View>
-        </TouchableOpacity>
-
-        <ExternalAlbumOptions album={album} />
+  const statusBadge =
+    status.kind === 'in_library' ? (
+      <Link size={14} color="#34C759" />
+    ) : status.kind === 'downloading' ? (
+      <View style={styles.badge}>
+        <ArrowDownCircle size={12} color="#007AFF" />
+        <Text style={[styles.badgeText, styles.badgeTextBlue]}>{status.progress}%</Text>
       </View>
-    </View>
+    ) : status.kind === 'none' && showExternalBadge ? (
+      <Cloud size={14} color={colors.subtext} />
+    ) : null;
+
+  return (
+    <MediaListRow
+      title={album.title}
+      subtitle={subtextOverride ?? album.subtext}
+      subtitleTrailing={statusBadge}
+      cover={album.cover}
+      onPress={handlePress}
+      trailing={<ExternalAlbumOptions album={album} />}
+    />
   );
 };
 
 export default memo(ExternalAlbumRow);
 
 const styles = StyleSheet.create({
-  wrapper: {
-    paddingHorizontal: 16,
-  },
-  cover: {
-    width: 64,
-    height: 64,
-    borderRadius: 6,
-  },
-  albumItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  albumContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  albumTextContainer: {
-    flex: 1,
-    marginLeft: 12,
-  },
-  albumTitle: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  subtextRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginTop: 2,
-    gap: 8,
-  },
-  subtextFlex: {
-    flex: 1,
-  },
-  albumSubtext: {
-    fontSize: 14,
-  },
   badge: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/components/rows/ExternalSongRow/index.tsx
+++ b/src/components/rows/ExternalSongRow/index.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { ExternalSong } from '@/types';
 import { useTheme } from '@/hooks/useTheme';
 import MediaListRow from '@/components/MediaListRow';
-import { spacing } from '@/constants/design';
 import ExternalSongOptions from '@/components/options/ExternalSongOptions';
 import { useDeezerSamplesEnabled } from '@/features/home/hooks/useDeezerEnabled';
 
@@ -50,7 +49,6 @@ const ExternalSongRow: React.FC<Props> = ({
       onPress={handlePress}
       showCover={false}
       variant="compact"
-      contentStyle={styles.content}
       rowStyle={styles.row}
       trailing={
         <View style={styles.rowRight}>
@@ -74,9 +72,6 @@ export default memo(ExternalSongRow);
 const styles = StyleSheet.create({
   row: {
     paddingVertical: 13,
-  },
-  content: {
-    marginRight: spacing.rowGap,
   },
   rowRight: {
     flexDirection: 'row',

--- a/src/components/rows/ExternalSongRow/index.tsx
+++ b/src/components/rows/ExternalSongRow/index.tsx
@@ -1,15 +1,14 @@
 import React, { memo, useCallback } from 'react';
 import {
   View,
-  Text,
   StyleSheet,
-  TouchableOpacity,
 } from 'react-native';
 import { PlayCircle } from 'lucide-react-native';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { useTranslation } from 'react-i18next';
 import { ExternalSong } from '@/types';
 import { useTheme } from '@/hooks/useTheme';
+import MediaListRow from '@/components/MediaListRow';
 import ExternalSongOptions from '@/components/options/ExternalSongOptions';
 import { useDeezerSamplesEnabled } from '@/features/home/hooks/useDeezerEnabled';
 
@@ -43,40 +42,29 @@ const ExternalSongRow: React.FC<Props> = ({
   }, [onPress, samplesEnabled, t]);
 
   return (
-    <View style={styles.row}>
-      <TouchableOpacity
-        style={styles.songInfo}
-        onPress={handlePress}
-        activeOpacity={0.6}
-      >
-        <View style={styles.textContainer}>
-          <Text
-            style={[styles.title, { color: colors.secondary }]}
-            numberOfLines={1}
-          >
-            {song.title}
-          </Text>
-          <Text
-            style={[styles.subtitle, { color: colors.subtext }]}
-            numberOfLines={1}
-          >
-            {song.artist || albumArtist}
-          </Text>
+    <MediaListRow
+      title={song.title}
+      subtitle={song.artist || albumArtist}
+      cover={song.cover}
+      onPress={handlePress}
+      showCover={false}
+      variant="compact"
+      contentStyle={styles.content}
+      rowStyle={styles.row}
+      trailing={
+        <View style={styles.rowRight}>
+          {hasPreview && (
+            <PlayCircle size={16} color={colors.subtext} />
+          )}
+          <ExternalSongOptions
+            song={song}
+            albumTitle={albumTitle}
+            albumArtist={albumArtist}
+            onPlay={previewUrl ? onPress : undefined}
+          />
         </View>
-      </TouchableOpacity>
-
-      <View style={styles.rowRight}>
-        {hasPreview && (
-          <PlayCircle size={16} color={colors.subtext} />
-        )}
-        <ExternalSongOptions
-          song={song}
-          albumTitle={albumTitle}
-          albumArtist={albumArtist}
-          onPlay={previewUrl ? onPress : undefined}
-        />
-      </View>
-    </View>
+      }
+    />
   );
 };
 
@@ -84,31 +72,14 @@ export default memo(ExternalSongRow);
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
     paddingVertical: 13,
-    paddingHorizontal: 16,
   },
-  songInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
+  content: {
     marginRight: 12,
-  },
-  textContainer: {
-    flex: 1,
   },
   rowRight: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-  },
-  title: {
-    fontSize: 15,
-    fontWeight: '400',
-  },
-  subtitle: {
-    fontSize: 13,
-    marginTop: 1,
   },
 });

--- a/src/components/rows/ExternalSongRow/index.tsx
+++ b/src/components/rows/ExternalSongRow/index.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { ExternalSong } from '@/types';
 import { useTheme } from '@/hooks/useTheme';
 import MediaListRow from '@/components/MediaListRow';
+import { spacing } from '@/constants/design';
 import ExternalSongOptions from '@/components/options/ExternalSongOptions';
 import { useDeezerSamplesEnabled } from '@/features/home/hooks/useDeezerEnabled';
 
@@ -75,7 +76,7 @@ const styles = StyleSheet.create({
     paddingVertical: 13,
   },
   content: {
-    marginRight: 12,
+    marginRight: spacing.rowGap,
   },
   rowRight: {
     flexDirection: 'row',

--- a/src/components/rows/SongRow/index.tsx
+++ b/src/components/rows/SongRow/index.tsx
@@ -94,7 +94,6 @@ const SongRow: React.FC<Props> = ({
         disabled={!onPress && !collection}
         showCover={!isAlbumCompact}
         variant="compact"
-        contentStyle={styles.mediaContent}
         rowStyle={isAlbumCompact ? styles.mediaRowAlbumCompact : undefined}
         trailing={
           <View style={styles.rowRight}>
@@ -127,9 +126,6 @@ const SongRow: React.FC<Props> = ({
 };
 
 const styles = StyleSheet.create({
-  mediaContent: {
-    marginRight: 12,
-  },
   mediaRowAlbumCompact: {
     paddingVertical: 13,
   },

--- a/src/components/rows/TopTrackRow/index.tsx
+++ b/src/components/rows/TopTrackRow/index.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import React, { memo } from 'react'
+import { StyleSheet, Text, TouchableOpacity } from 'react-native'
 import { Play } from 'lucide-react-native'
 import MediaListRow from '@/components/MediaListRow'
 import { useTheme } from '@/hooks/useTheme'
+import { spacing } from '@/constants/design'
 import { formatSongDuration } from '@/utils/formatDuration'
 import type { ExternalSong } from '@/types'
 
@@ -13,7 +14,7 @@ type Props = {
   onPress?: () => void
 }
 
-export default function TopTrackRow({ song, index, artistName, onPress }: Props) {
+function TopTrackRow({ song, index, artistName, onPress }: Props) {
   const { colors } = useTheme()
   const duration = formatSongDuration(song.duration)
 
@@ -32,18 +33,25 @@ export default function TopTrackRow({ song, index, artistName, onPress }: Props)
       }
       trailing={
         song.previewUrl ? (
-          <View style={[styles.previewButton, { backgroundColor: colors.card }]}>
+          <TouchableOpacity
+            style={[styles.previewButton, { backgroundColor: colors.card }]}
+            onPress={onPress}
+            disabled={!onPress}
+            hitSlop={8}
+          >
             <Play size={13} color={colors.secondary} fill={colors.secondary} />
-          </View>
+          </TouchableOpacity>
         ) : undefined
       }
     />
   )
 }
 
+export default memo(TopTrackRow)
+
 const styles = StyleSheet.create({
   content: {
-    marginRight: 12,
+    marginRight: spacing.rowGap,
   },
   trackIndex: {
     width: 16,

--- a/src/components/rows/TopTrackRow/index.tsx
+++ b/src/components/rows/TopTrackRow/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 import { Play } from 'lucide-react-native'
-import { MediaImage } from '@/components/MediaImage'
+import MediaListRow from '@/components/MediaListRow'
 import { useTheme } from '@/hooks/useTheme'
 import { formatSongDuration } from '@/utils/formatDuration'
 import type { ExternalSong } from '@/types'
@@ -18,62 +18,37 @@ export default function TopTrackRow({ song, index, artistName, onPress }: Props)
   const duration = formatSongDuration(song.duration)
 
   return (
-    <TouchableOpacity
-      style={styles.trackRow}
+    <MediaListRow
+      title={song.title}
+      subtitle={[artistName, duration].filter(Boolean).join(' • ')}
+      cover={song.cover}
       onPress={onPress}
-      disabled={!onPress}
-      activeOpacity={onPress ? 0.65 : 1}
-    >
-      <Text style={[styles.trackIndex, { color: colors.subtext }]}>
-        {index + 1}
-      </Text>
-      <MediaImage cover={song.cover} size="thumb" style={styles.trackCover} />
-      <View style={styles.trackText}>
-        <Text style={[styles.trackTitle, { color: colors.secondary }]} numberOfLines={1}>
-          {song.title}
+      variant="compact"
+      contentStyle={styles.content}
+      leading={
+        <Text style={[styles.trackIndex, { color: colors.subtext }]}>
+          {index + 1}
         </Text>
-        <Text style={[styles.trackSubtitle, { color: colors.subtext }]} numberOfLines={1}>
-          {[artistName, duration].filter(Boolean).join(' • ')}
-        </Text>
-      </View>
-      {song.previewUrl ? (
-        <View style={[styles.previewButton, { backgroundColor: colors.card }]}>
-          <Play size={13} color={colors.secondary} fill={colors.secondary} />
-        </View>
-      ) : null}
-    </TouchableOpacity>
+      }
+      trailing={
+        song.previewUrl ? (
+          <View style={[styles.previewButton, { backgroundColor: colors.card }]}>
+            <Play size={13} color={colors.secondary} fill={colors.secondary} />
+          </View>
+        ) : undefined
+      }
+    />
   )
 }
 
 const styles = StyleSheet.create({
-  trackRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 9,
+  content: {
+    marginRight: 12,
   },
   trackIndex: {
     width: 16,
     fontSize: 13,
     textAlign: 'left',
-  },
-  trackCover: {
-    width: 48,
-    height: 48,
-    borderRadius: 6,
-    marginRight: 12,
-  },
-  trackText: {
-    flex: 1,
-    marginRight: 12,
-  },
-  trackTitle: {
-    fontSize: 15,
-    fontWeight: '600',
-  },
-  trackSubtitle: {
-    fontSize: 13,
-    marginTop: 2,
   },
   previewButton: {
     width: 28,

--- a/src/components/rows/TopTrackRow/index.tsx
+++ b/src/components/rows/TopTrackRow/index.tsx
@@ -3,7 +3,6 @@ import { StyleSheet, Text, TouchableOpacity } from 'react-native'
 import { Play } from 'lucide-react-native'
 import MediaListRow from '@/components/MediaListRow'
 import { useTheme } from '@/hooks/useTheme'
-import { spacing } from '@/constants/design'
 import { formatSongDuration } from '@/utils/formatDuration'
 import type { ExternalSong } from '@/types'
 
@@ -25,7 +24,6 @@ function TopTrackRow({ song, index, artistName, onPress }: Props) {
       cover={song.cover}
       onPress={onPress}
       variant="compact"
-      contentStyle={styles.content}
       leading={
         <Text style={[styles.trackIndex, { color: colors.subtext }]}>
           {index + 1}
@@ -50,9 +48,6 @@ function TopTrackRow({ song, index, artistName, onPress }: Props) {
 export default memo(TopTrackRow)
 
 const styles = StyleSheet.create({
-  content: {
-    marginRight: spacing.rowGap,
-  },
   trackIndex: {
     width: 16,
     fontSize: 13,

--- a/src/screens/artist/components/Content/index.tsx
+++ b/src/screens/artist/components/Content/index.tsx
@@ -352,7 +352,6 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
     return (
       <ExternalAlbumRow
         album={item.album}
-        artistName={localArtist?.name ?? externalArtist?.name ?? ''}
         onPress={(album) => navigateToAlbum(album)}
         showExternalBadge={!!localArtist}
         subtextOverride={releaseYearLabel(item.album) ?? undefined}

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -161,7 +161,6 @@ const Search = () => {
             externalSource: result.externalSource,
             externalIds: result.externalIds,
           }}
-          artistName={result.subtext}
           onPress={album => {
             prefetchCovers([album.cover], 'detail');
             navigateToAlbum(album);


### PR DESCRIPTION
Parallel follow-up to #162/#163 (independent of #165 — no shared files). The three remaining hand-rolled list rows move onto `MediaListRow`, so external content lists match the migrated local ones.

## What changed
- `MediaListRow` gains two slots:
  - `leading` — rendered inside the touchable before the cover (TopTrackRow's track index)
  - `subtitleTrailing` — rendered on the subtitle line after the text (ExternalAlbumRow's in-library / downloading% / cloud badges)
- `ExternalAlbumRow` → default variant; it was a near-verbatim copy (64px cover, 16/500 title, 14 subtext), so no visual change beyond the shared code path.
- `TopTrackRow` → compact variant with `leading` index. Deliberate unifications: 48px cover → standard compact 44px, 15/600 title → standard compact 15/500, paddingVertical 9 → 10.
- `ExternalSongRow` → compact no-cover variant, matching the local album screen's `SongRow` albumCompact (same paddingVertical 13). Deliberate unification: 15/400 title → standard compact 15/500.

## Post-review fixes (self-review, high effort)
- **Bug fix:** the preview play circle in TopTrackRow had landed outside the row touchable (dead tap target); it's now its own `TouchableOpacity` with hit slop — better than the original, where it was only tappable as part of the row.
- `MediaListRow` renders the subtitle through a single path (the duplicate with/without-badges branches could drift apart), and `TopTrackRow` is memoized since artist sections render it in non-windowed `.map()` lists.
- `MediaListRow` now owns the content↔trailing gap (`gap: spacing.rowGap`); the `contentStyle` escape hatch and the three per-consumer `marginRight` overrides are gone. Trailing consumers that previously had no gap (album/artist/playlist/search rows) gain the standard 12px, so long titles now stop 12px short of the ellipsis button instead of touching it.
- Dropped `ExternalAlbumRow`'s required-but-never-used `artistName` prop and its two call sites.

## Behavior preserved
- Press handling unchanged, including ExternalSongRow's "enable samples" toast when tapped without a handler and TopTrackRow's disabled state when no `onPress`.
- All badges, preview indicators, and option-sheet triggers unchanged.

## Validation
- `npx tsc --noEmit`
- `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wi7RSs3KhyDvTp9ReHBmb