### PR TITLE
Playlist/album download progress ring with tap-to-cancel

### DIFF
--- a/src/components/DownloadProgressRing.tsx
+++ b/src/components/DownloadProgressRing.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import { X } from 'lucide-react-native';
+import { useTheme } from '@/hooks/useTheme';
+
+type Props = {
+  /** Aggregate progress in [0, 1] */
+  progress: number;
+  size?: number;
+  strokeWidth?: number;
+  color?: string;
+};
+
+/**
+ * Determinate circular progress ring with a centered cancel glyph, used in
+ * place of an indeterminate spinner where tapping the control cancels the
+ * download (the enclosing pressable owns the tap).
+ */
+export default function DownloadProgressRing({
+  progress,
+  size = 18,
+  strokeWidth = 2,
+  color,
+}: Props) {
+  const { colors } = useTheme();
+  const ringColor = color ?? colors.secondary;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const clamped = Math.max(0, Math.min(progress, 1));
+
+  return (
+    <View style={[styles.container, { width: size, height: size }]}>
+      <Svg width={size} height={size} style={StyleSheet.absoluteFill}>
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={ringColor}
+          strokeOpacity={0.25}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={ringColor}
+          strokeWidth={strokeWidth}
+          fill="none"
+          strokeDasharray={`${circumference}`}
+          strokeDashoffset={circumference * (1 - clamped)}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        />
+      </Svg>
+      <X size={size * 0.55} color={ringColor} strokeWidth={2.5} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/hooks/useCollectionDownloadProgress.ts
+++ b/src/hooks/useCollectionDownloadProgress.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { useDownloadState } from '@/contexts/DownloadContext';
+
+/**
+ * Aggregate download progress for a set of tracks in [0, 1]: completed tracks
+ * count as 1, in-flight tracks contribute their byte fraction, and tracks
+ * whose total size is unknown (transcoded streams report -1) count as 0 until
+ * they finish.
+ */
+export function useCollectionDownloadProgress(trackIds: string[]): number {
+  const { isTrackDownloaded, downloadProgress, downloadedTrackCount } = useDownloadState();
+
+  return useMemo(() => {
+    // isTrackDownloaded reads a ref and never changes identity, so
+    // downloadedTrackCount is depended on to recompute when a track finishes.
+    void downloadedTrackCount;
+
+    if (!trackIds.length) return 0;
+    let sum = 0;
+    for (const trackId of trackIds) {
+      if (isTrackDownloaded(trackId)) {
+        sum += 1;
+      } else {
+        const fraction = downloadProgress[trackId];
+        if (fraction && fraction > 0) sum += Math.min(fraction, 1);
+      }
+    }
+    return sum / trackIds.length;
+  }, [trackIds, isTrackDownloaded, downloadProgress, downloadedTrackCount]);
+}

--- a/src/screens/album/components/Header/index.tsx
+++ b/src/screens/album/components/Header/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   StyleSheet,
   TouchableOpacity,
-  ActivityIndicator,
 } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -19,6 +18,8 @@ import AlbumOptions from '@/components/options/AlbumOptions';
 import DownloadSheet from '@/components/options/DownloadSheet';
 import StatusBanner from '@/components/StatusBanner';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
+import DownloadProgressRing from '@/components/DownloadProgressRing';
+import { useCollectionDownloadProgress } from '@/hooks/useCollectionDownloadProgress';
 
 import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useDownload } from '@/contexts/DownloadContext';
@@ -201,12 +202,13 @@ function ExternalServerStatusRow({ album }: { album: ExternalAlbum }) {
 function LocalActionRow({ album }: { album: Album }) {
   const { colors } = useTheme();
   const { playSongInCollection } = usePlayingActions();
-  const { downloadAlbumById, getCollectionDownloadState } = useDownload();
+  const { downloadAlbumById, cancelCollectionDownloads, getCollectionDownloadState } = useDownload();
 
   const songs = useMemo(() => album.songs ?? [], [album.songs]);
   const songIds = useMemo(() => songs.map(s => s.id), [songs]);
   const { isDownloaded: isAlbumDownloaded, isDownloading: isAlbumDownloading } =
     getCollectionDownloadState(songIds);
+  const downloadFraction = useCollectionDownloadProgress(songIds);
 
   const checkmarkScale = useSharedValue(isAlbumDownloaded ? 1 : 0);
 
@@ -226,9 +228,13 @@ function LocalActionRow({ album }: { album: Album }) {
   }));
 
   const toggleDownload = useCallback(async () => {
-    if (!songs.length || isAlbumDownloading || isAlbumDownloaded) return;
+    if (isAlbumDownloading) {
+      await cancelCollectionDownloads(album.id);
+      return;
+    }
+    if (!songs.length || isAlbumDownloaded) return;
     await downloadAlbumById(album.id, songs);
-  }, [songs, isAlbumDownloading, isAlbumDownloaded, downloadAlbumById, album.id]);
+  }, [songs, isAlbumDownloading, isAlbumDownloaded, downloadAlbumById, cancelCollectionDownloads, album.id]);
 
   const handlePlay = useCallback(() => {
     if (songs.length > 0) playSongInCollection(songs[0], album, false);
@@ -248,12 +254,9 @@ function LocalActionRow({ album }: { album: Album }) {
         <Play size={20} color="#fff" fill="#fff" />
       </DetailPlayAction>
 
-      <DetailCircleAction
-        onPress={() => void toggleDownload()}
-        disabled={isAlbumDownloading}
-      >
+      <DetailCircleAction onPress={() => void toggleDownload()}>
         {isAlbumDownloading ? (
-          <ActivityIndicator size="small" color={colors.secondary} />
+          <DownloadProgressRing progress={downloadFraction} size={18} />
         ) : isAlbumDownloaded ? (
           <Animated.View style={checkmarkStyle}>
             <Check size={18} color={colors.secondary} />

--- a/src/screens/playlist/components/Header/index.tsx
+++ b/src/screens/playlist/components/Header/index.tsx
@@ -1,7 +1,4 @@
 import React, { useCallback, useMemo } from 'react';
-import {
-  ActivityIndicator,
-} from 'react-native';
 import { Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native';
 
 import { Playlist } from '@/types';
@@ -16,6 +13,8 @@ import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { useSheetRef } from '@/utils/useSheetRef';
 import { formatDuration } from '@/utils/formatDuration';
+import DownloadProgressRing from '@/components/DownloadProgressRing';
+import { useCollectionDownloadProgress } from '@/hooks/useCollectionDownloadProgress';
 import {
   DetailActionRow,
   DetailCircleAction,
@@ -39,12 +38,13 @@ const PlaylistHeader: React.FC<Props> = ({ playlist }) => {
   const dispatch = useDispatch();
   const activeServer = useSelector(selectActiveServer);
   const { playSongInCollection } = usePlaying();
-  const { downloadPlaylistById, getCollectionDownloadState } = useDownload();
+  const { downloadPlaylistById, cancelCollectionDownloads, getCollectionDownloadState } = useDownload();
 
   const songs = useMemo(() => playlist.songs ?? [], [playlist.songs]);
   const songIds = useMemo(() => songs.map(s => s.id), [songs]);
   const { isDownloaded: isPlaylistDownloaded, isDownloading: isPlaylistDownloading } =
     getCollectionDownloadState(songIds);
+  const downloadFraction = useCollectionDownloadProgress(songIds);
 
   const totalDuration = useMemo(
     () => songs.reduce((sum, song) => sum + Number(song.duration), 0),
@@ -60,9 +60,13 @@ const PlaylistHeader: React.FC<Props> = ({ playlist }) => {
   );
 
   const toggleDownload = useCallback(async () => {
-    if (!songs.length || isPlaylistDownloading || isPlaylistDownloaded) return;
+    if (isPlaylistDownloading) {
+      await cancelCollectionDownloads(playlist.id);
+      return;
+    }
+    if (!songs.length || isPlaylistDownloaded) return;
     await downloadPlaylistById(playlist.id, songs);
-  }, [songs, isPlaylistDownloading, isPlaylistDownloaded, downloadPlaylistById, playlist.id]);
+  }, [songs, isPlaylistDownloading, isPlaylistDownloaded, downloadPlaylistById, cancelCollectionDownloads, playlist.id]);
 
   const handleShuffle = useCallback(() => {
     if (!songs.length) return;
@@ -110,12 +114,9 @@ const PlaylistHeader: React.FC<Props> = ({ playlist }) => {
               <Play size={24} color="#fff" fill="#fff" />
             </DetailPlayAction>
 
-            <DetailCircleAction
-              onPress={() => void toggleDownload()}
-              disabled={isPlaylistDownloading}
-            >
+            <DetailCircleAction onPress={() => void toggleDownload()}>
               {isPlaylistDownloading ? (
-                <ActivityIndicator size="small" color={colors.secondary} />
+                <DownloadProgressRing progress={downloadFraction} size={18} />
               ) : isPlaylistDownloaded ? (
                 <Check size={18} color={colors.secondary} />
               ) : (


### PR DESCRIPTION
Implements #131.

- New `DownloadProgressRing` primitive (react-native-svg): determinate progress circle with a centered X, sized to sit inside `DetailCircleAction`.
- New `useCollectionDownloadProgress(trackIds)` hook: completed tracks count as 1, in-flight tracks contribute the byte fraction `DownloadContext` already reports (unknown-size transcoded streams count as 0 until they land), divided by total tracks — so the ring advances per-track even when sizes are unknown.
- Playlist and album headers: the download button is no longer disabled while downloading — tapping it cancels via the existing `cancelCollectionDownloads`. Already-downloaded tracks from a cancelled run remain on device (removable via the options sheet as before).

## Validation
- `npx tsc --noEmit`
- `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wi7RSs3KhyDvTp9ReHBmb