### PR TITLE
Localize remaining hardcoded strings in shared components

### DIFF
--- a/src/components/ExternalSourcePickerSheet/index.tsx
+++ b/src/components/ExternalSourcePickerSheet/index.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
 import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { renderBackdrop } from '@/components/BottomSheetBackdrop'
 import { getSourceMeta } from '@/features/sources/registry'
@@ -27,6 +28,7 @@ const COVER_SIZE = 48
 
 const ExternalSourcePickerSheet = forwardRef<BottomSheetModal, Props>(
   ({ items, isLoading, onSelect }, ref) => {
+    const { t } = useTranslation()
     const { colors } = useTheme()
     const sheetBg = useOptionSheetBackground()
 
@@ -55,7 +57,7 @@ const ExternalSourcePickerSheet = forwardRef<BottomSheetModal, Props>(
 
           {!isLoading && items.length === 0 && (
             <Text style={[styles.empty, { color: colors.subtext }]}>
-              No sources could resolve this item.
+              {t('externalSourcePicker.empty')}
             </Text>
           )}
 

--- a/src/components/SelectionBottomSheet.tsx
+++ b/src/components/SelectionBottomSheet.tsx
@@ -11,6 +11,7 @@ import {
   BottomSheetTextInput,
 } from '@gorhom/bottom-sheet'
 import { Dices } from 'lucide-react-native'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { renderBackdrop } from '@/components/BottomSheetBackdrop'
 
@@ -23,6 +24,7 @@ type Props = {
 
 const SelectionBottomSheet = forwardRef<BottomSheetModal, Props>(
   ({ items, onSelect, onRandomize, placeholder }, ref) => {
+    const { t } = useTranslation()
     const { colors } = useTheme()
     const [query, setQuery] = useState('')
 
@@ -70,7 +72,7 @@ const SelectionBottomSheet = forwardRef<BottomSheetModal, Props>(
             style={[styles.input, { color: colors.secondary }]}
             value={query}
             onChangeText={setQuery}
-            placeholder={placeholder ?? 'Search…'}
+            placeholder={placeholder ?? t('common.searchPlaceholder')}
             placeholderTextColor={colors.placeholder}
             autoCapitalize="words"
             autoCorrect={false}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -363,7 +363,8 @@
       "details": "Error: {{name}} {{message}}",
       "restart": "Restart"
     },
-    "serverUnreachableBanner": "Can't reach your server — showing local library data"
+    "serverUnreachableBanner": "Can't reach your server — showing local library data",
+    "searchPlaceholder": "Search…"
   },
   "onboarding": {
     "home": {
@@ -754,5 +755,8 @@
   },
   "external": {
     "notFound": "Couldn't find this in any connected source."
+  },
+  "externalSourcePicker": {
+    "empty": "No sources could resolve this item."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -388,7 +388,8 @@
     "more": "Plus",
     "less": "Moins",
     "playbackError": "Impossible de lire le morceau",
-    "serverUnreachableBanner": "Serveur injoignable — affichage des données locales"
+    "serverUnreachableBanner": "Serveur injoignable — affichage des données locales",
+    "searchPlaceholder": "Rechercher…"
   },
   "onboarding": {
     "home": {
@@ -815,5 +816,8 @@
     },
     "play": "lecture",
     "plays": "lectures"
+  },
+  "externalSourcePicker": {
+    "empty": "Aucune source n'a pu résoudre cet élément."
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -388,7 +388,8 @@
     "more": "もっと見る",
     "less": "閉じる",
     "playbackError": "曲を再生できません",
-    "serverUnreachableBanner": "サーバーに接続できません — ローカルのデータを表示中"
+    "serverUnreachableBanner": "サーバーに接続できません — ローカルのデータを表示中",
+    "searchPlaceholder": "検索…"
   },
   "onboarding": {
     "home": {
@@ -815,5 +816,8 @@
     },
     "play": "回再生",
     "plays": "回再生"
+  },
+  "externalSourcePicker": {
+    "empty": "この項目を解決できるソースがありません。"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -388,7 +388,8 @@
     "more": "更多",
     "less": "收起",
     "playbackError": "无法播放曲目",
-    "serverUnreachableBanner": "无法连接服务器 — 正在显示本地数据"
+    "serverUnreachableBanner": "无法连接服务器 — 正在显示本地数据",
+    "searchPlaceholder": "搜索…"
   },
   "onboarding": {
     "home": {
@@ -815,5 +816,8 @@
     },
     "play": "次播放",
     "plays": "次播放"
+  },
+  "externalSourcePicker": {
+    "empty": "没有来源能够解析此项目。"
   }
 }


### PR DESCRIPTION
Closes out the design-system follow-up noted on #165: shared components had two user-facing strings outside i18n.

- `ExternalSourcePickerSheet` empty state → `externalSourcePicker.empty`
- `SelectionBottomSheet` placeholder fallback → `common.searchPlaceholder`
- Keys added to en/fr/ja/zh.
- `ErrorBoundary` is left hardcoded deliberately — the crash screen must render even when the failure is in i18n initialization itself.

## Validation
- `npx tsc --noEmit`
- `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wi7RSs3KhyDvTp9ReHBmb