### PR TITLE
Improve detail UX and design system consistency

### DIFF
--- a/src/components/DetailHeader.tsx
+++ b/src/components/DetailHeader.tsx
@@ -39,6 +39,8 @@ export function DetailHeader({
       <View style={styles.headerRow}>
         <TouchableOpacity
           testID="detail-back-button"
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
           onPress={() => navigation.goBack()}
           style={styles.headerButton}
         >
@@ -161,11 +163,19 @@ export function DetailPlayAction({ children, onPress, disabled, style }: DetailP
 type DetailHeaderIconButtonProps = {
   children: React.ReactNode;
   onPress?: () => void;
+  accessibilityLabel?: string;
 };
 
-export function DetailHeaderIconButton({ children, onPress }: DetailHeaderIconButtonProps) {
+export function DetailHeaderIconButton({ children, onPress, accessibilityLabel = 'More options' }: DetailHeaderIconButtonProps) {
   return (
-    <TouchableOpacity onPress={onPress} style={styles.headerButton} activeOpacity={0.7}>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={styles.headerButton}
+      activeOpacity={0.7}
+      hitSlop={8}
+    >
       {children}
     </TouchableOpacity>
   );

--- a/src/components/DetailTopBar.tsx
+++ b/src/components/DetailTopBar.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { ChevronLeft } from 'lucide-react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '@/hooks/useTheme';
+import { controlSize, spacing, typography } from '@/constants/design';
+
+type Props = {
+  title: string;
+  visible: boolean;
+  rightAction?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+/** Compact detail navigation chrome shown after the large hero scrolls away. */
+export default function DetailTopBar({ title, visible, rightAction, style }: Props) {
+  const navigation = useNavigation<any>();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  return (
+    <View
+      pointerEvents={visible ? 'auto' : 'none'}
+      accessibilityElementsHidden={!visible}
+      style={[
+        styles.container,
+        {
+          paddingTop: insets.top,
+          height: insets.top + controlSize.topBarHeight,
+          backgroundColor: colors.overlay,
+          borderBottomColor: colors.border,
+          opacity: visible ? 1 : 0,
+        },
+        style,
+      ]}
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+        hitSlop={8}
+        onPress={() => navigation.goBack()}
+        style={styles.button}
+      >
+        <ChevronLeft size={24} color={colors.secondary} />
+      </TouchableOpacity>
+      <Text
+        accessibilityRole="header"
+        style={[styles.title, { color: colors.secondary }]}
+        numberOfLines={1}
+      >
+        {title}
+      </Text>
+      {rightAction ?? <View style={styles.button} />}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    zIndex: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.page,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  button: {
+    width: controlSize.iconCompact,
+    height: controlSize.iconCompact,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    flex: 1,
+    marginHorizontal: spacing.sm,
+    textAlign: 'center',
+    ...typography.navigationTitle,
+  },
+});

--- a/src/components/MediaListRow.tsx
+++ b/src/components/MediaListRow.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { MediaImage } from '@/components/MediaImage';
 import { useTheme } from '@/hooks/useTheme';
-import { controlSize, radius, spacing, typography } from '@/constants/design';
+import { controlSize, radius, rowDensity, spacing, typography } from '@/constants/design';
 import type { CoverSource } from '@/types';
 
 type Props = {
@@ -52,6 +52,9 @@ export default function MediaListRow({
     <View style={[styles.wrapper, style]}>
       <View style={[styles.row, isCompact && styles.compactRow, rowStyle]}>
         <TouchableOpacity
+          accessibilityRole={onPress ? 'button' : undefined}
+          accessibilityLabel={onPress ? title : undefined}
+          accessibilityState={{ disabled: disabled || !onPress }}
           style={styles.content}
           onPress={onPress}
           disabled={disabled || !onPress}
@@ -112,10 +115,7 @@ const styles = StyleSheet.create({
     gap: spacing.rowGap,
     marginBottom: 16,
   },
-  compactRow: {
-    marginBottom: 0,
-    paddingVertical: 10,
-  },
+  compactRow: rowDensity.compact,
   content: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/components/StatusBanner.tsx
+++ b/src/components/StatusBanner.tsx
@@ -20,12 +20,12 @@ type Props = {
 // per-mount state: the banner returns on the next visit, which is right for
 // transient conditions like connectivity.
 export default function StatusBanner({ icon, text, color, closable, style, testID }: Props) {
-  const { isDarkMode, colors } = useTheme();
+  const { colors } = useTheme();
   const [dismissed, setDismissed] = useState(false);
 
   if (dismissed) return null;
 
-  const background = isDarkMode ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)';
+  const background = colors.statusSurface;
   const textColor = color ?? colors.subtext;
 
   return (
@@ -36,6 +36,8 @@ export default function StatusBanner({ icon, text, color, closable, style, testI
       </Text>
       {closable && (
         <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss notification"
           onPress={() => setDismissed(true)}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           testID={testID ? `${testID}-close` : undefined}

--- a/src/constants/design.ts
+++ b/src/constants/design.ts
@@ -1,8 +1,15 @@
 export const spacing = {
   page: 16,
+  section: 24,
   rowGap: 12,
   controlGap: 10,
   inlineGap: 8,
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
 } as const;
 
 export const statusColor = {
@@ -13,18 +20,26 @@ export const statusColor = {
 } as const;
 
 export const radius = {
+  xs: 4,
+  sm: 6,
   thumb: 6,
+  md: 8,
   card: 12,
+  lg: 16,
   pill: 999,
 } as const;
 
 export const typography = {
-  detailTitle: { fontSize: 24, fontWeight: '600' as const },
-  sectionTitle: { fontSize: 20, fontWeight: '600' as const },
-  rowTitle: { fontSize: 16, fontWeight: '500' as const },
-  rowSubtitle: { fontSize: 14 },
-  compactRowTitle: { fontSize: 15, fontWeight: '500' as const },
-  compactRowSubtitle: { fontSize: 13 },
+  screenTitle: { fontSize: 24, lineHeight: 30, fontWeight: '600' as const },
+  detailTitle: { fontSize: 24, lineHeight: 30, fontWeight: '600' as const },
+  sectionTitle: { fontSize: 20, lineHeight: 25, fontWeight: '600' as const },
+  rowTitle: { fontSize: 16, lineHeight: 20, fontWeight: '500' as const },
+  rowSubtitle: { fontSize: 14, lineHeight: 18 },
+  compactRowTitle: { fontSize: 15, lineHeight: 19, fontWeight: '500' as const },
+  compactRowSubtitle: { fontSize: 13, lineHeight: 17 },
+  caption: { fontSize: 13, lineHeight: 17 },
+  button: { fontSize: 15, lineHeight: 20, fontWeight: '600' as const },
+  navigationTitle: { fontSize: 18, lineHeight: 22, fontWeight: '600' as const },
 } as const;
 
 export const controlSize = {
@@ -35,4 +50,31 @@ export const controlSize = {
   detailPrimaryHeight: 48,
   mediaRowArt: 64,
   compactMediaRowArt: 44,
+  topBarHeight: 52,
 } as const;
+
+export const rowDensity = {
+  compact: { paddingVertical: 8, marginBottom: 0 },
+  standard: { paddingVertical: 10, marginBottom: 16 },
+  spacious: { paddingVertical: 13, marginBottom: 16 },
+} as const;
+
+export type SemanticThemeColors = {
+  themeColor: string;
+  background: string;
+  card: string;
+  text: string;
+  secondary: string;
+  subtext: string;
+  border: string;
+  muted: string;
+  placeholder: string;
+  overlay: string;
+  statusSurface: string;
+  onThemeColor: string;
+  success: string;
+  warning: string;
+  error: string;
+  sourceDeezer: string;
+  sourceLastfm: string;
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -5,6 +5,7 @@ import {
   selectThemeMode,
   selectThemeColor,
 } from '@/utils/redux/selectors/settingsSelectors';
+import type { SemanticThemeColors } from '@/constants/design';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
 export type ResolvedTheme = 'light' | 'dark';
@@ -20,7 +21,7 @@ export const useTheme = () => {
 
   const isDarkMode = resolved === 'dark';
 
-  const colors = useMemo(
+  const colors = useMemo<SemanticThemeColors>(
     () => ({
       themeColor,
       background: isDarkMode ? '#000' : '#F2F2F7',
@@ -31,6 +32,14 @@ export const useTheme = () => {
       border: isDarkMode ? '#444' : '#ccc',
       muted: isDarkMode ? '#333' : '#eee',
       placeholder: isDarkMode ? '#666' : '#999',
+      overlay: isDarkMode ? 'rgba(0,0,0,0.82)' : 'rgba(242,242,247,0.92)',
+      statusSurface: isDarkMode ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.05)',
+      onThemeColor: '#fff',
+      success: '#34C759',
+      warning: '#FF9500',
+      error: '#FF3B30',
+      sourceDeezer: '#A238CA',
+      sourceLastfm: '#D51007',
     }),
     [isDarkMode, themeColor]
   );

--- a/src/screens/album/components/Content/ExternalAlbumBody.tsx
+++ b/src/screens/album/components/Content/ExternalAlbumBody.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 
@@ -8,6 +8,7 @@ import ExternalSongRow from '@/components/rows/ExternalSongRow';
 import { useExternalAlbumPreviews } from '@/hooks/albums/useExternalAlbumPreviews';
 import { usePreviewPlayer, externalSongToTrack } from '@/hooks/usePreviewPlayer';
 import { useTheme } from '@/hooks/useTheme';
+import DetailTopBar from '@/components/DetailTopBar';
 
 const H_PADDING = 16;
 
@@ -20,6 +21,11 @@ const ExternalAlbumBody: React.FC<Props> = ({ album }) => {
   const songs = useMemo(() => album.songs ?? [], [album.songs]);
   const previews = useExternalAlbumPreviews(album);
   const { toggleInAlbum } = usePreviewPlayer();
+  const [showTopBar, setShowTopBar] = useState(false);
+  const handleScroll = useCallback((event: { nativeEvent: { contentOffset: { y: number } } }) => {
+    const next = event.nativeEvent.contentOffset.y > 80;
+    setShowTopBar(previous => previous === next ? previous : next);
+  }, []);
 
   const albumPreviewSongs = useMemo(() =>
     songs
@@ -63,16 +69,21 @@ const ExternalAlbumBody: React.FC<Props> = ({ album }) => {
   }, [previews, handleSongPress, album.title, album.artist]);
 
   return (
-    <FlashList
-      data={songs}
-      keyExtractor={(item) => item.id}
-      renderItem={renderItem}
-      extraData={handleSongPress}
-      ListHeaderComponent={<AlbumHeader localAlbum={null} externalAlbum={album} />}
-      ListFooterComponent={footer}
-      contentContainerStyle={{ paddingBottom: Platform.OS === 'android' ? 180 : 140 }}
-      showsVerticalScrollIndicator={false}
-    />
+    <>
+      <FlashList
+        data={songs}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        extraData={handleSongPress}
+        ListHeaderComponent={<AlbumHeader localAlbum={null} externalAlbum={album} />}
+        ListFooterComponent={footer}
+        contentContainerStyle={{ paddingBottom: Platform.OS === 'android' ? 180 : 140 }}
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      />
+      <DetailTopBar title={album.title} visible={showTopBar} />
+    </>
   );
 };
 

--- a/src/screens/album/components/Content/LocalAlbumBody.tsx
+++ b/src/screens/album/components/Content/LocalAlbumBody.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Platform, Text, View, ScrollView, StyleSheet, useWindowDimensions } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { FlashList } from '@shopify/flash-list';
@@ -16,6 +16,7 @@ import { useStarredSongs } from '@/hooks/starred';
 import { useSelector } from 'react-redux';
 import { selectAlbumPlayCount } from '@/utils/redux/selectors/statsSelectors';
 import AlbumRecommendedSection from '../AlbumRecommendedSection';
+import DetailTopBar from '@/components/DetailTopBar';
 
 type Props = {
   album: Album;
@@ -46,6 +47,11 @@ const LocalAlbumBody: React.FC<Props> = ({ album, songsLoading }) => {
     () => new Set(starredSongs.map(song => song.id)),
     [starredSongs]
   );
+  const [showTopBar, setShowTopBar] = useState(false);
+  const handleScroll = useCallback((event: { nativeEvent: { contentOffset: { y: number } } }) => {
+    const next = event.nativeEvent.contentOffset.y > 80;
+    setShowTopBar(previous => previous === next ? previous : next);
+  }, []);
 
   const moreAlbums = useMemo(() => {
     return artistAlbums.filter(a => a.id !== album.id);
@@ -155,25 +161,30 @@ const LocalAlbumBody: React.FC<Props> = ({ album, songsLoading }) => {
   }, [colors, starredSongIds, album, t]);
 
   return (
-    <FlashList
-      data={items}
-      keyExtractor={(item) =>
-        item.type === 'disc-header' ? `disc-${item.disc}` :
-        item.type === 'skeleton' ? item.id :
-        item.song.id
-      }
-      renderItem={renderItem}
-      extraData={starredSongIds}
-      getItemType={(item) => item.type}
-      overrideItemLayout={(layout, item) => {
-        (layout as { size?: number }).size =
-          item.type === 'disc-header' ? DISC_HEADER_HEIGHT : ESTIMATED_ROW_HEIGHT;
-      }}
-      ListHeaderComponent={<AlbumHeader localAlbum={album} externalAlbum={null} />}
-      ListFooterComponent={footer}
-      contentContainerStyle={{ paddingBottom: Platform.OS === 'android' ? 180 : 140 }}
-      showsVerticalScrollIndicator={false}
-    />
+    <>
+      <FlashList
+        data={items}
+        keyExtractor={(item) =>
+          item.type === 'disc-header' ? `disc-${item.disc}` :
+          item.type === 'skeleton' ? item.id :
+          item.song.id
+        }
+        renderItem={renderItem}
+        extraData={starredSongIds}
+        getItemType={(item) => item.type}
+        overrideItemLayout={(layout, item) => {
+          (layout as { size?: number }).size =
+            item.type === 'disc-header' ? DISC_HEADER_HEIGHT : ESTIMATED_ROW_HEIGHT;
+        }}
+        ListHeaderComponent={<AlbumHeader localAlbum={album} externalAlbum={null} />}
+        ListFooterComponent={footer}
+        contentContainerStyle={{ paddingBottom: Platform.OS === 'android' ? 180 : 140 }}
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      />
+      <DetailTopBar title={album.title} visible={showTopBar} />
+    </>
   );
 };
 

--- a/src/screens/artist/components/Content/index.tsx
+++ b/src/screens/artist/components/Content/index.tsx
@@ -27,6 +27,7 @@ import { useSelector } from 'react-redux'
 import { selectLastFmSimilarArtistsEnabled } from '@/utils/redux/selectors/lastfmSelectors'
 import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelectors'
 import { selectLibraryAlbums } from '@/utils/redux/selectors/librarySelectors'
+import DetailTopBar from '@/components/DetailTopBar'
 
 type Props = {
   localArtist: Artist | null
@@ -189,6 +190,11 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
   const { t } = useTranslation()
   const [visibleAlbumsCount, setVisibleAlbumsCount] = useState(INITIAL_RELEASE_ROWS)
   const [visibleSinglesCount, setVisibleSinglesCount] = useState(INITIAL_RELEASE_ROWS)
+  const [showTopBar, setShowTopBar] = useState(false)
+  const handleScroll = useCallback((event: { nativeEvent: { contentOffset: { y: number } } }) => {
+    const next = event.nativeEvent.contentOffset.y > 80
+    setShowTopBar(previous => previous === next ? previous : next)
+  }, [])
   const localAlbums = useArtistAlbums(localArtist?.id ?? '')
   const { tracks: libraryTracks } = useTracks()
   const { data: externalDiscography } = useArtistExternalDiscography(localArtist?.name ?? null, !!localArtist)
@@ -361,17 +367,25 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
   }, [colors, localArtist, externalArtist, navigation, navigateToAlbum, setVisibleAlbumsCount, setVisibleSinglesCount, t])
 
   return (
-    <FlashList
-      data={items}
-      keyExtractor={(item) => item.id}
-      ListHeaderComponent={<Header localArtist={localArtist} externalArtist={externalArtist} />}
-      renderItem={renderItem}
-      showsVerticalScrollIndicator={false}
-      contentContainerStyle={{
-        paddingBottom: Platform.OS === 'android' ? 180 : 140,
-        backgroundColor: colors.background,
-      }}
-    />
+    <>
+      <FlashList
+        data={items}
+        keyExtractor={(item) => item.id}
+        ListHeaderComponent={<Header localArtist={localArtist} externalArtist={externalArtist} />}
+        renderItem={renderItem}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingBottom: Platform.OS === 'android' ? 180 : 140,
+          backgroundColor: colors.background,
+        }}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      />
+      <DetailTopBar
+        title={localArtist?.name ?? externalArtist?.name ?? ''}
+        visible={showTopBar}
+      />
+    </>
   )
 }
 

--- a/src/screens/artist/components/Header/index.tsx
+++ b/src/screens/artist/components/Header/index.tsx
@@ -66,7 +66,7 @@ const ArtistHeader: React.FC<Props> = ({ localArtist, externalArtist }) => {
           <View
             style={[
               StyleSheet.absoluteFill,
-              { backgroundColor: isDarkMode ? '#1a1a1a' : '#e5e5e5' },
+              { backgroundColor: colors.muted },
             ]}
           />
         )}
@@ -95,6 +95,8 @@ const ArtistHeader: React.FC<Props> = ({ localArtist, externalArtist }) => {
         <View style={styles.header}>
           <TouchableOpacity
             testID="detail-back-button"
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
             style={styles.backButton}
             onPress={() => navigation.goBack()}
           >
@@ -136,6 +138,8 @@ function LocalOptionsButton({ artist }: { artist: Artist }) {
   return (
     <>
       <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel="Artist options"
         style={styles.backButton}
         onPress={() => optionsSheetRef.current?.present()}
       >

--- a/src/screens/playlist/components/Content/index.tsx
+++ b/src/screens/playlist/components/Content/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +11,7 @@ import { useStarredSongs } from '@/hooks/starred';
 
 import Header from '../Header';
 import RecommendedSection from '../RecommendedSection';
+import DetailTopBar from '@/components/DetailTopBar';
 
 type Props = {
   playlist: Playlist;
@@ -29,6 +30,11 @@ const PlaylistContent: React.FC<Props> = ({ playlist, songsLoading }) => {
     () => new Set(starredSongs.map(song => song.id)),
     [starredSongs]
   );
+  const [showTopBar, setShowTopBar] = useState(false);
+  const handleScroll = useCallback((event: { nativeEvent: { contentOffset: { y: number } } }) => {
+    const next = event.nativeEvent.contentOffset.y > 80;
+    setShowTopBar(previous => previous === next ? previous : next);
+  }, []);
 
   const items = useMemo<ListItem[]>(() => {
     if (songsLoading) {
@@ -54,16 +60,21 @@ const PlaylistContent: React.FC<Props> = ({ playlist, songsLoading }) => {
   }, [starredSongIds, playlist]);
 
   return (
-    <FlashList<ListItem>
-      data={items}
-      keyExtractor={(item, index) => item.type === 'song' ? `${item.song.id}:${index}` : item.id}
-      renderItem={renderItem}
-      ListHeaderComponent={<Header playlist={playlist} />}
-      ListFooterComponent={<RecommendedSection playlist={playlist} />}
-      ListEmptyComponent={songsLoading ? null : <SectionEmptyState message={t('playlist.empty')} />}
-      contentContainerStyle={{ paddingBottom: Platform.OS === 'android' ? 180 : 140 }}
-      showsVerticalScrollIndicator={false}
-    />
+    <>
+      <FlashList<ListItem>
+        data={items}
+        keyExtractor={(item, index) => item.type === 'song' ? `${item.song.id}:${index}` : item.id}
+        renderItem={renderItem}
+        ListHeaderComponent={<Header playlist={playlist} />}
+        ListFooterComponent={<RecommendedSection playlist={playlist} />}
+        ListEmptyComponent={songsLoading ? null : <SectionEmptyState message={t('playlist.empty')} />}
+        contentContainerStyle={{ paddingBottom: Platform.OS === 'android' ? 180 : 140 }}
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      />
+      <DetailTopBar title={playlist.title} visible={showTopBar} />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a compact sticky detail top bar for album, artist, and playlist screens
- expand shared spacing, radius, typography, control, row-density, and semantic color tokens
- standardize detail/row accessibility labels, roles, and disabled states
- use semantic status surfaces and theme-aware artist fallback styling

## UX notes
The large detail hero continues to scroll normally. Once the user scrolls past the hero, a compact back/title bar appears so navigation context remains available without permanently consuming the hero's vertical space.

## Verification
- `npm run lint`
- `npx tsc --noEmit`
- `npx jest --ci --runInBand` (27 suites, 116 tests)
- `git diff --check`
