### PR TITLE
AudioMuse-AI integration, playback performance, and recent searches

### DIFF
--- a/src/components/options/PlaylistOptions.tsx
+++ b/src/components/options/PlaylistOptions.tsx
@@ -8,7 +8,7 @@ import { ListEnd, Play, Shuffle, List, CheckCircle, ArrowDownCircle, Trash2, Pen
 import { toast } from '@backpackapp-io/react-native-toast';
 
 import { Playlist, PlaylistBase } from '@/types';
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useDownload } from '@/contexts/DownloadContext';
 import { useNavigation } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
@@ -59,7 +59,7 @@ const PlaylistOptions = forwardRef<
     addCollectionToQueue,
     shuffleCollectionToQueue,
     getQueue,
-  } = usePlaying();
+  } = usePlayingActions();
 
   const { downloadPlaylistById, getCollectionDownloadState } =
     useDownload();

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -799,9 +799,15 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     bumpQueue();
   }, [bumpQueue, resolvePlayableSong]);
 
+  // AudioMuse-AI first when configured, native similar-songs as fallback —
+  // same tiered provider Autoplay and Smart Shuffle use, so "Play Similar"
+  // gets acoustic similarity too instead of always hitting the native API.
   const playSimilar = useCallback(async (song: Song) => {
     try {
-      const similarSongs = await api.similar.getSimilarSongs(song.id);
+      const provider = resolveQueueFillProvider(providersRef.current);
+      const similarSongs = provider
+        ? await provider.fetchExtension({ recentSongs: [song], excludeIds: new Set([song.id]), count: 20 })
+        : await api.similar.getSimilarSongs(song.id);
       const others = similarSongs.filter(s => s.id !== song.id);
       const songs = [song, ...shuffleArray(others)];
       const collection: Playlist = {

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -22,10 +22,12 @@ import { usePlaylists } from '@/hooks/playlists';
 
 import { useTracks } from '@/hooks/tracks';
 import { useApi } from '@/api';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   selectSearchScope,
 } from '@/utils/redux/selectors/settingsSelectors';
+import { selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
+import { addSearchQuery } from '@/utils/redux/slices/searchHistorySlice';
 import { useDownload } from '@/contexts/DownloadContext';
 import {
   buildDownloadedTrackIdSet,
@@ -209,12 +211,14 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
   children,
 }) => {
   const api = useApi();
+  const dispatch = useDispatch();
   const { albums } = useAlbums();
   const { artists } = useArtists();
   const { playlists } = usePlaylists();
   const { tracks } = useTracks();
 
   const searchScope = useSelector(selectSearchScope);
+  const activeServerId = useSelector(selectActiveServerId);
 
   const {
     downloadedTracks,
@@ -353,6 +357,8 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
       setHasError(false);
       return;
     }
+    if (activeServerId) dispatch(addSearchQuery({ serverId: activeServerId, query }));
+
     setIsLoading(true);
     let errored = false;
     try {
@@ -380,7 +386,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     } finally {
       if (requestId === searchRequestIdRef.current) setIsLoading(false);
     }
-  }, [searchExternal, searchLibrary, searchScope, searchServer]);
+  }, [activeServerId, dispatch, searchExternal, searchLibrary, searchScope, searchServer]);
 
   const value = useMemo<SearchContextType>(() => ({
     searchResults,

--- a/src/contexts/queueProviders.test.ts
+++ b/src/contexts/queueProviders.test.ts
@@ -1,0 +1,134 @@
+import type { Song } from '@/types';
+import type { ApiAdapter } from '@/api/types';
+import { getAudiomuseQueueExtension } from '@/api/audiomuse/similarity';
+import {
+  resolveQueueFillProvider,
+  createNativeSimilarityQueueFillProvider,
+  createAudiomuseQueueFillProvider,
+  type QueueFillProvider,
+} from './queueProviders';
+
+jest.mock('@/api/audiomuse/client', () => ({
+  createAudiomuseClient: jest.fn(() => ({ request: jest.fn(), baseUrl: '' })),
+}));
+jest.mock('@/api/audiomuse/similarity', () => ({
+  getAudiomuseQueueExtension: jest.fn(),
+}));
+
+const song = (id: string): Song => ({
+  id,
+  title: id,
+  artist: 'Artist',
+  artistId: 'artist-1',
+  cover: { kind: 'none' },
+  duration: '120',
+  albumId: 'album-1',
+  streamUrl: `https://example.com/${id}.mp3`,
+});
+
+function fakeApi(overrides: Partial<ApiAdapter> = {}): ApiAdapter {
+  return {
+    auth: { connect: jest.fn(), ping: jest.fn(), testUrl: jest.fn(), startScan: jest.fn(), disconnect: jest.fn() },
+    albums: { list: jest.fn(), get: jest.fn() },
+    artists: { list: jest.fn(), get: jest.fn() },
+    genres: { list: jest.fn() },
+    playlists: { list: jest.fn(), get: jest.fn(), create: jest.fn(), rename: jest.fn(), addSong: jest.fn(), removeSong: jest.fn(), delete: jest.fn() },
+    starred: { list: jest.fn(), add: jest.fn(), remove: jest.fn() },
+    songs: { get: jest.fn(async () => null), scrobble: jest.fn(), buildStreamUrl: jest.fn() },
+    tracks: { list: jest.fn(), get: jest.fn() },
+    similar: { getSimilarSongs: jest.fn(async () => []) },
+    lyrics: { getBySongId: jest.fn() },
+    search: { search: jest.fn() },
+    ...overrides,
+  } as ApiAdapter;
+}
+
+describe('resolveQueueFillProvider', () => {
+  const provider = (id: QueueFillProvider['id'], available: boolean): QueueFillProvider => ({
+    id,
+    isAvailable: () => available,
+    fetchExtension: jest.fn(async () => []),
+  });
+
+  it('returns the first available provider in priority order', () => {
+    const audiomuse = provider('audiomuse', true);
+    const native = provider('native-similarity', true);
+    expect(resolveQueueFillProvider([audiomuse, native])).toBe(audiomuse);
+  });
+
+  it('skips unavailable providers', () => {
+    const audiomuse = provider('audiomuse', false);
+    const native = provider('native-similarity', true);
+    expect(resolveQueueFillProvider([audiomuse, native])).toBe(native);
+  });
+
+  it('returns null when no provider is available', () => {
+    expect(resolveQueueFillProvider([provider('audiomuse', false)])).toBeNull();
+  });
+});
+
+describe('createNativeSimilarityQueueFillProvider', () => {
+  it('is always available', () => {
+    const provider = createNativeSimilarityQueueFillProvider(fakeApi());
+    expect(provider.isAvailable()).toBe(true);
+  });
+
+  it('returns nothing when there are no seed songs', async () => {
+    const provider = createNativeSimilarityQueueFillProvider(fakeApi());
+    const result = await provider.fetchExtension({ recentSongs: [], excludeIds: new Set(), count: 10 });
+    expect(result).toEqual([]);
+  });
+
+  it('seeds from the last recent song and excludes already-queued ids', async () => {
+    const getSimilarSongs = jest.fn(async () => [song('a'), song('b'), song('c')]);
+    const api = fakeApi({ similar: { getSimilarSongs } });
+    const provider = createNativeSimilarityQueueFillProvider(api);
+
+    const result = await provider.fetchExtension({
+      recentSongs: [song('x'), song('seed')],
+      excludeIds: new Set(['b']),
+      count: 10,
+    });
+
+    expect(getSimilarSongs).toHaveBeenCalledWith('seed');
+    expect(result.map(s => s.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('caps the result at count', async () => {
+    const many = ['a', 'b', 'c', 'd', 'e'].map(song);
+    const api = fakeApi({ similar: { getSimilarSongs: jest.fn(async () => many) } });
+    const provider = createNativeSimilarityQueueFillProvider(api);
+
+    const result = await provider.fetchExtension({ recentSongs: [song('seed')], excludeIds: new Set(), count: 2 });
+    expect(result.length).toBe(2);
+  });
+});
+
+describe('createAudiomuseQueueFillProvider', () => {
+  const config = { serverUrl: 'http://audiomuse:8000', apiToken: 'token' };
+
+  it('is available only when both serverUrl and apiToken are set', () => {
+    expect(createAudiomuseQueueFillProvider(config, fakeApi()).isAvailable()).toBe(true);
+    expect(createAudiomuseQueueFillProvider({ serverUrl: '', apiToken: 'token' }, fakeApi()).isAvailable()).toBe(false);
+    expect(createAudiomuseQueueFillProvider({ serverUrl: config.serverUrl, apiToken: '' }, fakeApi()).isAvailable()).toBe(false);
+  });
+
+  it('resolves similarity refs to library songs, dropping unresolvable and excluded ones', async () => {
+    (getAudiomuseQueueExtension as jest.Mock).mockResolvedValue([
+      { itemId: 'a' },
+      { itemId: 'b' },
+      { itemId: 'missing' },
+    ]);
+    const get = jest.fn(async (id: string) => (id === 'missing' ? null : song(id)));
+    const api = fakeApi({ songs: { get, scrobble: jest.fn(), buildStreamUrl: jest.fn() } });
+    const provider = createAudiomuseQueueFillProvider(config, api);
+
+    const result = await provider.fetchExtension({
+      recentSongs: [song('seed')],
+      excludeIds: new Set(['b']),
+      count: 10,
+    });
+
+    expect(result.map(s => s.id)).toEqual(['a']);
+  });
+});

--- a/src/contexts/queueProviders.ts
+++ b/src/contexts/queueProviders.ts
@@ -13,7 +13,7 @@ export interface QueueFillProvider {
   id: 'audiomuse' | 'native-similarity';
   isAvailable(): boolean;
   fetchExtension(opts: {
-    recentSongs: Song[];
+    recentSongs: { id: string }[];
     excludeIds: Set<string>;
     count: number;
   }): Promise<Song[]>;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -488,7 +488,10 @@
     "title": "Search",
     "placeholder": "Search for music, artists, or playlists...",
     "noResults": "No results found",
-    "searchError": "Couldn't reach the server — results may be incomplete"
+    "searchError": "Couldn't reach the server — results may be incomplete",
+    "recentSearches": "Recent Searches",
+    "clearRecent": "Clear",
+    "removeRecentSearch": "Remove \"{{query}}\" from recent searches"
   },
   "artist": {
     "sections": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -212,7 +212,10 @@
       "showSleepTimer": "Minuterie de veille",
       "showSleepTimerSubtext": "Affiche une commande de minuterie de veille dans le lecteur.",
       "showPlaybackSpeed": "Vitesse de lecture",
-      "showPlaybackSpeedSubtext": "Affiche une commande de vitesse dans le lecteur."
+      "showPlaybackSpeedSubtext": "Affiche une commande de vitesse dans le lecteur.",
+      "autoplay": "Lecture automatique",
+      "autoplaySubtextAudiomuse": "Continue de jouer des titres sonoriquement similaires une fois la file d'attente terminée, grâce à AudioMuse-AI.",
+      "autoplaySubtextNative": "Continue de jouer des titres similaires depuis votre serveur une fois la file d'attente terminée."
     },
     "listenBrainz": {
       "title": "ListenBrainz",
@@ -300,6 +303,20 @@
       "artistSection": "Artiste",
       "albumSection": "Album",
       "playlistSection": "Playlist"
+    },
+    "audiomuse": {
+      "title": "AudioMuse-AI",
+      "credentialsHelper": "Connectez-vous à une instance AudioMuse-AI auto-hébergée pointant vers ce serveur pour une Lecture aléatoire intelligente et des Transitions fluides basées sur l'analyse sonore.",
+      "serverUrl": "URL du serveur",
+      "serverUrlPlaceholder": "http://audiomuse:8000",
+      "apiToken": "Jeton API",
+      "apiTokenPlaceholder": "Jeton API",
+      "connectivity": "Connectivité",
+      "connectionFailed": "Échec de la connexion à AudioMuse-AI",
+      "enable": "Activer AudioMuse-AI",
+      "enableSubtext": "Utiliser AudioMuse-AI pour la Lecture aléatoire intelligente et les Transitions fluides une fois connecté.",
+      "disconnect": "Déconnecter",
+      "disconnected": "Déconnecté d'AudioMuse-AI."
     },
     "scrobbling": {
       "title": "Scrobbling",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -521,6 +521,10 @@
     "title": "Recherche",
     "placeholder": "Rechercher de la musique, des artistes ou des listes de lecture...",
     "noResults": "Aucun résultat trouvé",
+    "searchError": "Impossible de joindre le serveur — les résultats peuvent être incomplets",
+    "recentSearches": "Recherches récentes",
+    "clearRecent": "Effacer",
+    "removeRecentSearch": "Supprimer « {{query}} » des recherches récentes",
     "chips": {
       "local": "Local",
       "external": "Externe",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -520,6 +520,10 @@
     "title": "検索",
     "placeholder": "音楽、アーティスト、プレイリストを検索...",
     "noResults": "結果が見つかりません",
+    "searchError": "サーバーに接続できませんでした — 結果が不完全な場合があります",
+    "recentSearches": "最近の検索",
+    "clearRecent": "クリア",
+    "removeRecentSearch": "「{{query}}」を最近の検索から削除",
     "chips": {
       "local": "ローカル",
       "external": "外部",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -211,7 +211,10 @@
       "showSleepTimer": "スリープタイマー",
       "showSleepTimerSubtext": "プレイヤーにスリープタイマーを表示します。",
       "showPlaybackSpeed": "再生速度",
-      "showPlaybackSpeedSubtext": "プレイヤーに速度調整を表示します。"
+      "showPlaybackSpeedSubtext": "プレイヤーに速度調整を表示します。",
+      "autoplay": "自動再生",
+      "autoplaySubtextAudiomuse": "AudioMuse-AIを使って、キューが終わった後も音響的に似た曲を再生し続けます。",
+      "autoplaySubtextNative": "キューが終わった後も、サーバー内の似た曲を再生し続けます。"
     },
     "listenBrainz": {
       "title": "ListenBrainz",
@@ -299,6 +302,20 @@
       "artistSection": "アーティスト",
       "albumSection": "アルバム",
       "playlistSection": "プレイリスト"
+    },
+    "audiomuse": {
+      "title": "AudioMuse-AI",
+      "credentialsHelper": "このサーバーに接続されたセルフホストのAudioMuse-AIインスタンスに接続すると、音響解析に基づくスマートシャッフルとスムーズな切り替えが利用できます。",
+      "serverUrl": "サーバーURL",
+      "serverUrlPlaceholder": "http://audiomuse:8000",
+      "apiToken": "APIトークン",
+      "apiTokenPlaceholder": "APIトークン",
+      "connectivity": "接続状況",
+      "connectionFailed": "AudioMuse-AIへの接続に失敗しました",
+      "enable": "AudioMuse-AIを有効にする",
+      "enableSubtext": "接続時にスマートシャッフルとスムーズな切り替えにAudioMuse-AIを使用します。",
+      "disconnect": "切断",
+      "disconnected": "AudioMuse-AIから切断しました。"
     },
     "scrobbling": {
       "title": "スクロブル",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -520,6 +520,10 @@
     "title": "搜索",
     "placeholder": "搜索音乐、歌手或播放列表...",
     "noResults": "未找到结果",
+    "searchError": "无法连接服务器 — 结果可能不完整",
+    "recentSearches": "最近搜索",
+    "clearRecent": "清除",
+    "removeRecentSearch": "从最近搜索中删除“{{query}}”",
     "chips": {
       "local": "本地",
       "external": "外部",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -211,7 +211,10 @@
       "showSleepTimer": "睡眠定时器",
       "showSleepTimerSubtext": "在播放器中显示睡眠定时器控件。",
       "showPlaybackSpeed": "播放速度",
-      "showPlaybackSpeedSubtext": "在播放器中显示速度控件。"
+      "showPlaybackSpeedSubtext": "在播放器中显示速度控件。",
+      "autoplay": "自动播放",
+      "autoplaySubtextAudiomuse": "队列播放完毕后，使用 AudioMuse-AI 继续播放声音相似的曲目。",
+      "autoplaySubtextNative": "队列播放完毕后，继续播放服务器中的相似曲目。"
     },
     "listenBrainz": {
       "title": "ListenBrainz",
@@ -299,6 +302,20 @@
       "artistSection": "艺术家",
       "albumSection": "专辑",
       "playlistSection": "播放列表"
+    },
+    "audiomuse": {
+      "title": "AudioMuse-AI",
+      "credentialsHelper": "连接到指向此服务器的自托管 AudioMuse-AI 实例，以启用基于声音分析的智能随机播放和平滑过渡。",
+      "serverUrl": "服务器地址",
+      "serverUrlPlaceholder": "http://audiomuse:8000",
+      "apiToken": "API 令牌",
+      "apiTokenPlaceholder": "API 令牌",
+      "connectivity": "连接状态",
+      "connectionFailed": "连接 AudioMuse-AI 失败",
+      "enable": "启用 AudioMuse-AI",
+      "enableSubtext": "连接后使用 AudioMuse-AI 实现智能随机播放和平滑过渡。",
+      "disconnect": "断开连接",
+      "disconnected": "已断开与 AudioMuse-AI 的连接。"
     },
     "scrobbling": {
       "title": "Scrobbling",

--- a/src/screens/artist/components/Header/index.tsx
+++ b/src/screens/artist/components/Header/index.tsx
@@ -17,7 +17,7 @@ import { useSelector } from 'react-redux';
 import { MediaImage } from '@/components/MediaImage';
 import ArtistOptions from '@/components/options/ArtistOptions';
 import { Artist, ExternalArtist, Song } from '@/types';
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { useArtistAlbums } from '@/hooks/artists';
 import { useTracks } from '@/hooks/tracks';
@@ -232,7 +232,7 @@ function LocalActionRow({ artist }: { artist: Artist }) {
   const api = useApi();
   const activeServer = useSelector(selectActiveServer);
 
-  const { playSongInCollection } = usePlaying();
+  const { playSongInCollection } = usePlayingActions();
   const { downloadAlbumById, getCollectionDownloadState } = useDownload();
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
   const [songsLoading, setSongsLoading] = useState(false);

--- a/src/screens/genre/components/Header/index.tsx
+++ b/src/screens/genre/components/Header/index.tsx
@@ -22,7 +22,7 @@ import { fetchAlbumDetailsSettled } from '@/hooks/albums'
 import { buildCover } from '@/utils/builders/buildCover'
 import { useTheme } from '@/hooks/useTheme'
 import { useTracks } from '@/hooks/tracks'
-import { usePlaying } from '@/contexts/PlayingContext'
+import { usePlayingActions } from '@/contexts/PlayingContext'
 import { useDownload } from '@/contexts/DownloadContext'
 import { useSheetRef } from '@/utils/useSheetRef'
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors'
@@ -41,7 +41,7 @@ const GenreHeader: React.FC<Props> = ({ genre, albums, showNavigation = true }) 
   const api = useApi()
   const { isDarkMode, colors } = useTheme()
   const activeServer = useSelector(selectActiveServer)
-  const { playSongInCollection } = usePlaying()
+  const { playSongInCollection } = usePlayingActions()
   const { downloadAlbumById, getCollectionDownloadState } = useDownload()
   const { t } = useTranslation()
 

--- a/src/screens/home/components/QuickPicksSection/index.tsx
+++ b/src/screens/home/components/QuickPicksSection/index.tsx
@@ -11,7 +11,7 @@ import { toast } from '@backpackapp-io/react-native-toast';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/hooks/useTheme';
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import { usePlayableSongResolver } from '@/hooks/songs';
 import { useSongActionSheets } from '@/contexts/SongActionSheetContext';
 import IconActionButton from '@/components/IconActionButton';
@@ -68,7 +68,7 @@ type Props = { refreshKey?: number };
 export default function QuickPicksSection({ refreshKey = 0 }: Props) {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { playSong } = usePlaying();
+  const { playSong } = usePlayingActions();
   const { resolvePlayableSong } = usePlayableSongResolver();
   const picks = useQuickPicks(refreshKey);
   const { width: screenWidth } = useWindowDimensions();

--- a/src/screens/library/components/AccountBottomSheet.tsx
+++ b/src/screens/library/components/AccountBottomSheet.tsx
@@ -3,7 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { Settings, RefreshCw, LogOut } from 'lucide-react-native';
 import { useSelector, useDispatch } from 'react-redux';
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useRouter } from 'expo-router';
 import { useApi } from '@/api';
 import { disconnect } from '@/utils/redux/slices/serversSlice';
@@ -35,7 +35,7 @@ const AccountBottomSheet = forwardRef<BottomSheetModal, Props>(({ onDismiss }, r
   const themeColor = useSelector(selectThemeColor);
 
   const queryClient = useQueryClient();
-  const { pauseSong, resetQueue } = usePlaying();
+  const { pauseSong, resetQueue } = usePlayingActions();
 
   const initial = username?.[0]?.toUpperCase() ?? '?';
   const cleanUrl = serverUrl?.replace(/^https?:\/\//, '');

--- a/src/screens/library/components/Items/TrackItem.tsx
+++ b/src/screens/library/components/Items/TrackItem.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useRef } from "react";
 import { InteractionManager } from "react-native";
 import { useSongActionSheets } from '@/contexts/SongActionSheetContext';
-import { usePlaying } from "@/contexts/PlayingContext";
+import { usePlayingActions } from "@/contexts/PlayingContext";
 import { SongBase } from "@/types";
 import { useTranslation } from "react-i18next";
 import { toast } from "@backpackapp-io/react-native-toast";
@@ -18,7 +18,7 @@ type Props = {
 
 const TrackItem: React.FC<Props> = ({ song, isGridView, gridWidth, gridSpacing }) => {
   const { t } = useTranslation();
-  const { playSimilar, playSong } = usePlaying();
+  const { playSimilar, playSong } = usePlayingActions();
   const { resolvePlayableSong } = usePlayableSongResolver();
   const { openSongOptions } = useSongActionSheets();
 

--- a/src/screens/playlist/components/Header/index.tsx
+++ b/src/screens/playlist/components/Header/index.tsx
@@ -4,7 +4,7 @@ import { Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native';
 import { Playlist } from '@/types';
 import PlaylistOptions from '@/components/options/PlaylistOptions';
 
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useDownload } from '@/contexts/DownloadContext';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
@@ -40,7 +40,7 @@ const PlaylistHeader: React.FC<Props> = ({ playlist, showNavigation = true, onOp
 
   const dispatch = useDispatch();
   const activeServer = useSelector(selectActiveServer);
-  const { playSongInCollection } = usePlaying();
+  const { playSongInCollection } = usePlayingActions();
   const { downloadPlaylistById, cancelCollectionDownloads, getCollectionDownloadState } = useDownload();
 
   const songs = useMemo(() => playlist.songs ?? [], [playlist.songs]);

--- a/src/screens/playlist/components/RecommendedSection/index.tsx
+++ b/src/screens/playlist/components/RecommendedSection/index.tsx
@@ -17,8 +17,18 @@ import IconActionButton from '@/components/IconActionButton';
 import MediaListRow from '@/components/MediaListRow';
 import SectionHeader from '@/components/SectionHeader';
 import { usePlaying } from '@/contexts/PlayingContext';
+import { createAudiomuseQueueFillProvider } from '@/contexts/queueProviders';
 import { usePreviewPlayer } from '@/hooks/usePreviewPlayer';
-import { selectThemeColor, selectShowSourceHeaders, selectDeezerDiscoveryEnabled } from '@/utils/redux/selectors/settingsSelectors';
+import { useApi } from '@/api';
+import {
+  selectThemeColor,
+  selectShowSourceHeaders,
+  selectDeezerDiscoveryEnabled,
+} from '@/utils/redux/selectors/settingsSelectors';
+import {
+  selectIsAudiomuseConfigured,
+  selectAudiomuseConfig,
+} from '@/utils/redux/selectors/audiomuseSelectors';
 import { useAddSongToPlaylist } from '@/hooks/playlists';
 import { useTracks } from '@/hooks/tracks';
 import { usePlayableSongResolver } from '@/hooks/songs';
@@ -231,6 +241,10 @@ export const LocalRecommendedSection: React.FC<LocalRecommendedSectionProps> = (
   const { t } = useTranslation();
   const { colors } = useTheme();
   const { tracks } = useTracks();
+  const api = useApi();
+  const isOffline = useIsOffline();
+  const isAudiomuseConfigured = useSelector(selectIsAudiomuseConfigured);
+  const audiomuseConfig = useSelector(selectAudiomuseConfig);
 
   const playlistSongIds = useMemo(
     () => new Set((playlist.songs ?? []).map(s => s.id)),
@@ -247,13 +261,43 @@ export const LocalRecommendedSection: React.FC<LocalRecommendedSectionProps> = (
     return [...names].slice(0, 3);
   }, [playlist.songs]);
 
-  const localSongs = useMemo<SongBase[]>(() => {
+  // Same-artist shuffle from the local library — used whenever AudioMuse-AI
+  // isn't configured, and as a safety net if its similarity call fails.
+  const fallbackLocalSongs = useMemo<SongBase[]>(() => {
     const artistSet = new Set(playlistArtistNames.map(n => n.toLowerCase()));
     const pool = tracks.filter(
       s => !playlistSongIds.has(s.id) && s.artist && artistSet.has(s.artist.toLowerCase())
     );
     return seededShuffle(pool, localSeed).slice(0, LOCAL_COUNT);
   }, [tracks, playlistSongIds, playlistArtistNames, localSeed]);
+
+  // Reseed a handful of playlist tracks each refresh so acoustic similarity
+  // results vary too, matching the fallback's shuffled feel.
+  const audiomuseSeeds = useMemo(
+    () => seededShuffle(playlist.songs ?? [], localSeed).slice(0, 5),
+    [playlist.songs, localSeed]
+  );
+
+  const audiomuseQuery = useQuery({
+    queryKey: [
+      QueryKeys.RecommendedLocalSongs,
+      'audiomuse',
+      playlist.id,
+      audiomuseSeeds.map(s => s.id).join(','),
+    ],
+    queryFn: () => createAudiomuseQueueFillProvider(audiomuseConfig, api).fetchExtension({
+      recentSongs: audiomuseSeeds,
+      excludeIds: playlistSongIds,
+      count: LOCAL_COUNT,
+    }),
+    enabled: isAudiomuseConfigured && !isOffline && audiomuseSeeds.length > 0,
+    staleTime: 1000 * 60 * 30,
+    networkMode: 'online',
+  });
+
+  const localSongs: SongBase[] = audiomuseQuery.data?.length
+    ? audiomuseQuery.data
+    : fallbackLocalSongs;
 
   if (localSongs.length === 0) return null;
 

--- a/src/screens/playlist/components/RecommendedSection/index.tsx
+++ b/src/screens/playlist/components/RecommendedSection/index.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '@/hooks/useTheme';
 import IconActionButton from '@/components/IconActionButton';
 import MediaListRow from '@/components/MediaListRow';
 import SectionHeader from '@/components/SectionHeader';
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import { createAudiomuseQueueFillProvider } from '@/contexts/queueProviders';
 import { usePreviewPlayer } from '@/hooks/usePreviewPlayer';
 import { useApi } from '@/api';
@@ -138,7 +138,7 @@ type LocalRowProps = {
 const LocalRow: React.FC<LocalRowProps> = ({ song, playlistId }) => {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { playSimilar } = usePlaying();
+  const { playSimilar } = usePlayingActions();
   const { resolvePlayableSong } = usePlayableSongResolver();
   const addToPlaylist = useAddSongToPlaylist();
   const [adding, setAdding] = useState(false);

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -21,7 +21,7 @@ import SkeletonListRow from '@/components/SkeletonListRow';
 import StatusBanner from '@/components/StatusBanner';
 import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
-import { usePlaying } from '@/contexts/PlayingContext';
+import { usePlayingActions } from '@/contexts/PlayingContext';
 import IconActionButton from '@/components/IconActionButton';
 import MediaListRow from '@/components/MediaListRow';
 import { useSongActionSheets } from '@/contexts/SongActionSheetContext';
@@ -45,7 +45,7 @@ const Search = () => {
   const { navigateToAlbum, navigateToArtist } = useMatchedNavigation();
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { playSong } = usePlaying();
+  const { playSong } = usePlayingActions();
   const { resolvePlayableSong } = usePlayableSongResolver();
   const deezerSearchEnabled = useDeezerSearchEnabled();
   const showSourceHeaders = useSelector(selectShowSourceHeaders);

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   Text,
 } from 'react-native';
-import { CloudOff, Ellipsis, X } from 'lucide-react-native';
+import { Clock, CloudOff, Ellipsis, X } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -30,9 +30,11 @@ import { usePrefetchCovers } from '@/hooks/usePrefetchCovers';
 import { prefetchCovers } from '@/utils/images/imageCache';
 import { usePlayableSongResolver } from '@/hooks/songs';
 import { useDeezerSearchEnabled } from '@/features/home/hooks/useDeezerEnabled';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelectors';
-import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
+import { selectActiveServer, selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
+import { selectSearchHistoryForActiveServer } from '@/utils/redux/selectors/searchHistorySelectors';
+import { removeSearchQuery, clearSearchHistory } from '@/utils/redux/slices/searchHistorySlice';
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
 import HomeHeader from '@/screens/library/components/Header';
@@ -45,11 +47,14 @@ const Search = () => {
   const { navigateToAlbum, navigateToArtist } = useMatchedNavigation();
   const { t } = useTranslation();
   const { colors } = useTheme();
+  const dispatch = useDispatch();
   const { playSong } = usePlayingActions();
   const { resolvePlayableSong } = usePlayableSongResolver();
   const deezerSearchEnabled = useDeezerSearchEnabled();
   const showSourceHeaders = useSelector(selectShowSourceHeaders);
   const username = useSelector(selectActiveServer)?.username;
+  const activeServerId = useSelector(selectActiveServerId);
+  const recentSearches = useSelector(selectSearchHistoryForActiveServer);
   const { openAccountSheet } = useAccountSheet();
 
   const [query, setQuery] = useState('');
@@ -64,6 +69,12 @@ const Search = () => {
     };
   }, []);
 
+  const runSearch = (text: string) => {
+    clearSearch();
+    setHasSearched(true);
+    void handleSearchWithFilters(text, { local: true, deezer: deezerSearchEnabled });
+  };
+
   const onSearchChange = (text: string) => {
     setQuery(text);
     if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
@@ -72,11 +83,22 @@ const Search = () => {
       setHasSearched(false);
       return;
     }
-    typingTimeoutRef.current = setTimeout(async () => {
-      clearSearch();
-      setHasSearched(true);
-      await handleSearchWithFilters(text, { local: true, deezer: deezerSearchEnabled });
-    }, 300);
+    typingTimeoutRef.current = setTimeout(() => runSearch(text), 300);
+  };
+
+  const handleRecentPress = (value: string) => {
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+    Keyboard.dismiss();
+    setQuery(value);
+    runSearch(value);
+  };
+
+  const handleRemoveRecent = (value: string) => {
+    if (activeServerId) dispatch(removeSearchQuery({ serverId: activeServerId, query: value }));
+  };
+
+  const handleClearRecent = () => {
+    if (activeServerId) dispatch(clearSearchHistory({ serverId: activeServerId }));
   };
 
   const handleSongPress = async (result: SearchResult) => {
@@ -254,45 +276,81 @@ const Search = () => {
         />
       )}
 
-      <ScrollView contentContainerStyle={styles.scrollContent}>
-        {isLoading
-          ? [...Array(8)].map((_, i) => <SkeletonListRow key={i} />)
-          : (
-            <>
-              {localResults.map(result => (
-                <View key={`local:${result.type}:${result.id}`} style={styles.resultBlock}>
-                  {renderResult(result)}
-                </View>
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        {query.trim() === ''
+          ? recentSearches.length > 0 && (
+            <View style={styles.recentSection} testID="search-recent-section">
+              <View style={styles.recentHeader}>
+                <Text style={[styles.recentTitle, { color: colors.subtext }]}>
+                  {t('search.recentSearches')}
+                </Text>
+                <TouchableOpacity onPress={handleClearRecent} hitSlop={8}>
+                  <Text style={[styles.recentClear, { color: colors.subtext }]}>
+                    {t('search.clearRecent')}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              {recentSearches.map(item => (
+                <TouchableOpacity
+                  key={item}
+                  testID="search-recent-item"
+                  style={styles.recentRow}
+                  onPress={() => handleRecentPress(item)}
+                >
+                  <Clock size={16} color={colors.subtext} />
+                  <Text style={[styles.recentQuery, { color: colors.secondary }]} numberOfLines={1}>
+                    {item}
+                  </Text>
+                  <TouchableOpacity
+                    onPress={() => handleRemoveRecent(item)}
+                    hitSlop={10}
+                    style={styles.recentRemove}
+                    accessibilityLabel={t('search.removeRecentSearch', { query: item })}
+                  >
+                    <X size={16} color={colors.subtext} />
+                  </TouchableOpacity>
+                </TouchableOpacity>
               ))}
-
-              {Array.from(externalResultsBySource.entries()).map(([sourceId, results]) => {
-                const meta = getSourceMeta(sourceId);
-                const label = meta?.label ?? sourceId;
-                const color = meta?.color ?? colors.subtext;
-                const letter = label.charAt(0).toUpperCase();
-                return (
-                  <React.Fragment key={sourceId}>
-                    <View style={styles.sourceHeader}>
-                      {showSourceHeaders && (
-                        <View style={[styles.sourceBadge, { backgroundColor: color }]}>
-                          <Text style={styles.sourceBadgeLetter}>{letter}</Text>
-                        </View>
-                      )}
-                      <Text style={[styles.sourceHeaderText, { color: colors.subtext }]}>{label}</Text>
-                    </View>
-                    {results.map((result, i) => (
-                      <View key={`external:${result.type}:${result.id}`} style={[styles.resultBlock, i === 0 && styles.resultBlockFirst]}>
-                        {renderResult(result)}
-                      </View>
-                    ))}
-                  </React.Fragment>
-                );
-              })}
-            </>
+            </View>
           )
+          : isLoading
+            ? [...Array(8)].map((_, i) => <SkeletonListRow key={i} />)
+            : (
+              <>
+                {localResults.map(result => (
+                  <View key={`local:${result.type}:${result.id}`} style={styles.resultBlock}>
+                    {renderResult(result)}
+                  </View>
+                ))}
+
+                {Array.from(externalResultsBySource.entries()).map(([sourceId, results]) => {
+                  const meta = getSourceMeta(sourceId);
+                  const label = meta?.label ?? sourceId;
+                  const color = meta?.color ?? colors.subtext;
+                  const letter = label.charAt(0).toUpperCase();
+                  return (
+                    <React.Fragment key={sourceId}>
+                      <View style={styles.sourceHeader}>
+                        {showSourceHeaders && (
+                          <View style={[styles.sourceBadge, { backgroundColor: color }]}>
+                            <Text style={styles.sourceBadgeLetter}>{letter}</Text>
+                          </View>
+                        )}
+                        <Text style={[styles.sourceHeaderText, { color: colors.subtext }]}>{label}</Text>
+                      </View>
+                      {results.map((result, i) => (
+                        <View key={`external:${result.type}:${result.id}`} style={[styles.resultBlock, i === 0 && styles.resultBlockFirst]}>
+                          {renderResult(result)}
+                        </View>
+                      ))}
+                    </React.Fragment>
+                  );
+                })}
+              </>
+            )
         }
 
-        {hasSearched && !isLoading && searchResults.length === 0 && (
+        {query.trim() !== '' && hasSearched && !isLoading && searchResults.length === 0 && (
           <Text testID="search-no-results" style={[styles.noResults, { color: colors.subtext }]}>
             {t('search.noResults')}
           </Text>
@@ -371,5 +429,38 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 24,
     fontSize: 16,
+  },
+  recentSection: {
+    paddingTop: 4,
+  },
+  recentHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  recentTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  recentClear: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  recentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  recentQuery: {
+    flex: 1,
+    fontSize: 15,
+  },
+  recentRemove: {
+    padding: 4,
   },
 });

--- a/src/utils/redux/selectors/searchHistorySelectors.ts
+++ b/src/utils/redux/selectors/searchHistorySelectors.ts
@@ -1,0 +1,10 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from '@/utils/redux/store';
+
+const EMPTY: string[] = [];
+
+export const selectSearchHistoryForActiveServer = createSelector(
+  [(s: RootState) => s.searchHistory.byServer, (s: RootState) => s.servers.activeServerId],
+  (byServer, activeServerId): string[] =>
+    (activeServerId ? byServer[activeServerId] ?? EMPTY : EMPTY)
+);

--- a/src/utils/redux/slices/searchHistorySlice.test.ts
+++ b/src/utils/redux/slices/searchHistorySlice.test.ts
@@ -1,0 +1,62 @@
+import reducer, {
+  addSearchQuery,
+  removeSearchQuery,
+  clearSearchHistory,
+} from './searchHistorySlice'
+
+describe('searchHistorySlice', () => {
+  it('adds a query to the front of the history for that server', () => {
+    let state = reducer(undefined, addSearchQuery({ serverId: 's1', query: 'taylor swift' }))
+    state = reducer(state, addSearchQuery({ serverId: 's1', query: 'radiohead' }))
+
+    expect(state.byServer.s1).toEqual(['radiohead', 'taylor swift'])
+  })
+
+  it('moves a re-searched query back to the front instead of duplicating it', () => {
+    let state = reducer(undefined, addSearchQuery({ serverId: 's1', query: 'taylor swift' }))
+    state = reducer(state, addSearchQuery({ serverId: 's1', query: 'radiohead' }))
+    state = reducer(state, addSearchQuery({ serverId: 's1', query: 'Taylor Swift' }))
+
+    expect(state.byServer.s1).toEqual(['Taylor Swift', 'radiohead'])
+  })
+
+  it('ignores empty or whitespace-only queries', () => {
+    const state = reducer(undefined, addSearchQuery({ serverId: 's1', query: '   ' }))
+    expect(state.byServer.s1).toBeUndefined()
+  })
+
+  it('caps history at 10 entries per server, dropping the oldest', () => {
+    let state = reducer(undefined, { type: 'init' } as any)
+    for (let i = 0; i < 12; i++) {
+      state = reducer(state, addSearchQuery({ serverId: 's1', query: `q${i}` }))
+    }
+
+    expect(state.byServer.s1).toHaveLength(10)
+    expect(state.byServer.s1[0]).toBe('q11')
+    expect(state.byServer.s1).not.toContain('q0')
+    expect(state.byServer.s1).not.toContain('q1')
+  })
+
+  it('keeps history separate per server', () => {
+    let state = reducer(undefined, addSearchQuery({ serverId: 's1', query: 'a' }))
+    state = reducer(state, addSearchQuery({ serverId: 's2', query: 'b' }))
+
+    expect(state.byServer.s1).toEqual(['a'])
+    expect(state.byServer.s2).toEqual(['b'])
+  })
+
+  it('removes a single query', () => {
+    let state = reducer(undefined, addSearchQuery({ serverId: 's1', query: 'a' }))
+    state = reducer(state, addSearchQuery({ serverId: 's1', query: 'b' }))
+    state = reducer(state, removeSearchQuery({ serverId: 's1', query: 'a' }))
+
+    expect(state.byServer.s1).toEqual(['b'])
+  })
+
+  it('clears all history for a server', () => {
+    let state = reducer(undefined, addSearchQuery({ serverId: 's1', query: 'a' }))
+    state = reducer(state, clearSearchHistory({ serverId: 's1' }))
+
+    expect(state.byServer.s1).toEqual([])
+  })
+})

--- a/src/utils/redux/slices/searchHistorySlice.ts
+++ b/src/utils/redux/slices/searchHistorySlice.ts
@@ -1,0 +1,45 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface SearchHistoryState {
+  byServer: Record<string, string[]>;
+}
+
+const initialState: SearchHistoryState = {
+  byServer: {},
+};
+
+const MAX_ENTRIES = 10;
+
+type ServerRef = { serverId: string };
+
+const searchHistorySlice = createSlice({
+  name: 'searchHistory',
+  initialState,
+  reducers: {
+    addSearchQuery(state, action: PayloadAction<ServerRef & { query: string }>) {
+      const { serverId, query } = action.payload;
+      const trimmed = query.trim();
+      if (!trimmed) return;
+      const existing = state.byServer[serverId] ?? [];
+      const deduped = existing.filter(q => q.toLowerCase() !== trimmed.toLowerCase());
+      state.byServer[serverId] = [trimmed, ...deduped].slice(0, MAX_ENTRIES);
+    },
+    removeSearchQuery(state, action: PayloadAction<ServerRef & { query: string }>) {
+      const { serverId, query } = action.payload;
+      const existing = state.byServer[serverId];
+      if (!existing) return;
+      state.byServer[serverId] = existing.filter(q => q !== query);
+    },
+    clearSearchHistory(state, action: PayloadAction<ServerRef>) {
+      state.byServer[action.payload.serverId] = [];
+    },
+  },
+});
+
+export const {
+  addSearchQuery,
+  removeSearchQuery,
+  clearSearchHistory,
+} = searchHistorySlice.actions;
+
+export default searchHistorySlice.reducer;

--- a/src/utils/redux/store.ts
+++ b/src/utils/redux/store.ts
@@ -12,6 +12,7 @@ import statsReducer from './slices/statsSlice';
 import libraryReducer from './slices/librarySlice';
 import libraryStarredReducer from './slices/libraryStarredSlice';
 import offlineMutationsReducer from './slices/offlineMutationsSlice';
+import searchHistoryReducer from './slices/searchHistorySlice';
 
 // Returns undefined (→ initialState) only on version bump; otherwise passes state through.
 const resetMigrate = (state: any, currentVersion: number): Promise<any> => {
@@ -42,6 +43,7 @@ const settingsPersistConfig = {
 const listenbrainzPersistConfig = { key: 'listenbrainz', storage };
 const lastfmPersistConfig = { key: 'lastfm', storage };
 const offlineMutationsPersistConfig = { key: 'offlineMutations', storage };
+const searchHistoryPersistConfig = { key: 'searchHistory', storage };
 
 const statsPersistConfig = {
   key: 'stats',
@@ -73,6 +75,7 @@ export const rootReducer = combineReducers({
     library: libraryReducer,
     libraryStarred: libraryStarredReducer,
     offlineMutations: offlineMutationsReducer,
+    searchHistory: searchHistoryReducer,
 });
 
 const persistedReducer = combineReducers({
@@ -86,6 +89,7 @@ const persistedReducer = combineReducers({
     library: persistReducer(libraryPersistConfig, libraryReducer),
     libraryStarred: persistReducer(libraryStarredPersistConfig, libraryStarredReducer),
     offlineMutations: persistReducer(offlineMutationsPersistConfig, offlineMutationsReducer),
+    searchHistory: persistReducer(searchHistoryPersistConfig, searchHistoryReducer),
 });
 
 const store = configureStore({


### PR DESCRIPTION
## Summary
- Extends AudioMuse-AI beyond Autoplay/Smart Shuffle: playlist "From your library" recommendations and the "Play Similar" action now use AudioMuse's acoustic similarity when configured (previously both used naive same-artist/native-only logic even with AudioMuse connected), reusing the existing `QueueFillProvider` abstraction.
- Fixes a re-render bug where action-only components (`TrackItem` and 8 others) subscribed to the combined `usePlaying()` hook and re-rendered on every playback state change instead of just the actions they needed — most notably defeating `TrackItem`'s `React.memo` on every track change, a real jank source while scrolling the library during playback. Switched to the narrower `usePlayingActions()`, matching the split already used elsewhere (`SongOptions`, `Controls`, `Queue`, `PlayingBarBase`).
- Adds recent searches to the search screen, which previously showed nothing until you typed: a per-server `searchHistory` slice recorded on each executed search, shown as a tappable/removable/clearable list when the search field is empty.
- Fills in missing fr/ja/zh translations for the AudioMuse-AI settings screen, the Autoplay toggle, and the search error string — these existed only in `en.json`.
- Adds test coverage for `queueProviders.ts` (previously untested despite backing Autoplay, Smart Shuffle, and Play Similar) and `searchHistorySlice.ts`.

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx jest --ci` — 138 tests passing (30 suites, including 2 new test files)

## Related issues
None filed — this continues ad hoc integration/performance work on `dev`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3mnXvMuRSrd1sPugbnrKQ)_