### PR TITLE
Fix recent searches: no mid-typing captures, drop uppercase header

### DIFF
--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -22,12 +22,10 @@ import { usePlaylists } from '@/hooks/playlists';
 
 import { useTracks } from '@/hooks/tracks';
 import { useApi } from '@/api';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   selectSearchScope,
 } from '@/utils/redux/selectors/settingsSelectors';
-import { selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
-import { addSearchQuery } from '@/utils/redux/slices/searchHistorySlice';
 import { useDownload } from '@/contexts/DownloadContext';
 import {
   buildDownloadedTrackIdSet,
@@ -211,14 +209,12 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
   children,
 }) => {
   const api = useApi();
-  const dispatch = useDispatch();
   const { albums } = useAlbums();
   const { artists } = useArtists();
   const { playlists } = usePlaylists();
   const { tracks } = useTracks();
 
   const searchScope = useSelector(selectSearchScope);
-  const activeServerId = useSelector(selectActiveServerId);
 
   const {
     downloadedTracks,
@@ -357,8 +353,6 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
       setHasError(false);
       return;
     }
-    if (activeServerId) dispatch(addSearchQuery({ serverId: activeServerId, query }));
-
     setIsLoading(true);
     let errored = false;
     try {
@@ -386,7 +380,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     } finally {
       if (requestId === searchRequestIdRef.current) setIsLoading(false);
     }
-  }, [activeServerId, dispatch, searchExternal, searchLibrary, searchScope, searchServer]);
+  }, [searchExternal, searchLibrary, searchScope, searchServer]);
 
   const value = useMemo<SearchContextType>(() => ({
     searchResults,

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -34,7 +34,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelectors';
 import { selectActiveServer, selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
 import { selectSearchHistoryForActiveServer } from '@/utils/redux/selectors/searchHistorySelectors';
-import { removeSearchQuery, clearSearchHistory } from '@/utils/redux/slices/searchHistorySlice';
+import { addSearchQuery, removeSearchQuery, clearSearchHistory } from '@/utils/redux/slices/searchHistorySlice';
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
 import HomeHeader from '@/screens/library/components/Header';
@@ -75,6 +75,15 @@ const Search = () => {
     void handleSearchWithFilters(text, { local: true, deezer: deezerSearchEnabled });
   };
 
+  // Only called from deliberate actions (submitting, tapping a result, replaying a
+  // recent search) — never from the as-you-type debounce, or every paused keystroke
+  // would get saved as its own history entry.
+  const recordSearch = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || !activeServerId) return;
+    dispatch(addSearchQuery({ serverId: activeServerId, query: trimmed }));
+  };
+
   const onSearchChange = (text: string) => {
     setQuery(text);
     if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
@@ -86,11 +95,17 @@ const Search = () => {
     typingTimeoutRef.current = setTimeout(() => runSearch(text), 300);
   };
 
+  const onSearchSubmit = () => {
+    Keyboard.dismiss();
+    recordSearch(query);
+  };
+
   const handleRecentPress = (value: string) => {
     if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
     Keyboard.dismiss();
     setQuery(value);
     runSearch(value);
+    recordSearch(value);
   };
 
   const handleRemoveRecent = (value: string) => {
@@ -102,6 +117,7 @@ const Search = () => {
   };
 
   const handleSongPress = async (result: SearchResult) => {
+    recordSearch(query);
     try {
       if (result.song) { await playSong(result.song); return; }
       const song = await resolvePlayableSong(result.id);
@@ -178,6 +194,7 @@ const Search = () => {
             externalIds: result.externalIds,
           }}
           onPress={album => {
+            recordSearch(query);
             prefetchCovers([album.cover], 'detail');
             navigateToAlbum(album);
           }}
@@ -195,6 +212,7 @@ const Search = () => {
             created: new Date(0),
           }}
           onPress={album => {
+            recordSearch(query);
             prefetchCovers([album.cover], 'detail');
             navigation.navigate('albumView', { id: album.id });
           }}
@@ -208,6 +226,7 @@ const Search = () => {
           artist={{ id: result.id, name: result.title, subtext: result.subtext, cover: result.cover, albumIds: [] }}
           rounded
           onPress={() => {
+            recordSearch(query);
             prefetchCovers([result.cover], 'detail');
             if (result.source === 'external') {
               navigateToArtist({ id: result.id, name: result.title, cover: result.cover, subtext: result.subtext, externalSource: result.externalSource, externalIds: result.externalIds });
@@ -224,6 +243,7 @@ const Search = () => {
         <PlaylistRow
           playlist={{ id: result.id, title: result.title, subtext: result.subtext, cover: result.cover, changed: new Date(), created: new Date() }}
           onPress={() => {
+            recordSearch(query);
             prefetchCovers([result.cover], 'detail');
             navigation.navigate('playlistView', { id: result.id });
           }}
@@ -253,7 +273,7 @@ const Search = () => {
             value={query}
             onChangeText={onSearchChange}
             returnKeyType="search"
-            onSubmitEditing={Keyboard.dismiss}
+            onSubmitEditing={onSearchSubmit}
           />
           {query !== '' && (
             <TouchableOpacity
@@ -443,7 +463,6 @@ const styles = StyleSheet.create({
   recentTitle: {
     fontSize: 13,
     fontWeight: '600',
-    textTransform: 'uppercase',
   },
   recentClear: {
     fontSize: 13,


### PR DESCRIPTION
## Summary
Follow-up to #172 (merged), addressing review feedback on the recent-searches feature:
- Recording ran inside `handleSearchWithFilters`, which fires on every as-you-type debounce settle — so pausing mid-word saved a partial query as its own history entry. Recording now only happens on deliberate actions: submitting, tapping a result, or replaying a recent search.
- Removed the all-caps styling on the "Recent Searches" header.

Kept recent searches text-based rather than switching to "what you played/opened" — matches standard search UX (Spotify/Apple Music/Google) and avoids duplicating the existing "Recently Played" home section.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx jest --ci` — 138 tests passing (30 suites)

## Related issues
Follow-up to #172.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3mnXvMuRSrd1sPugbnrKQ)_