### PR TITLE
Vary AudioMuse queue-fill results and fix full-screen player re-render lag

### DIFF
--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -69,7 +69,6 @@ export interface PlayingStateType {
   isPlaying: boolean;
   isBuffering: boolean;
   currentIndex: number;
-  queueVersion: number;
   /** @deprecated use repeatMode instead */
   repeatOn: boolean;
   repeatMode: RepeatModeState;
@@ -110,6 +109,11 @@ export type PlayingContextType = PlayingStateType & PlayingActionsType;
 const PlayingStateContext = createContext<PlayingStateType | undefined>(undefined);
 const PlayingActionsContext = createContext<PlayingActionsType | undefined>(undefined);
 const PlayingProgressContext = createContext<PlaybackProgress>({ position: 0, duration: 0, buffered: 0 });
+// Split out of PlayingStateType: queueVersion bumps on every queue mutation
+// (add/remove/reorder/autoplay-fill), which is far more often than most
+// usePlayingState() consumers (the full-screen player, the mini bar, Controls)
+// need to re-render for. Only the queue list itself reads this.
+const PlayingQueueVersionContext = createContext<number>(0);
 
 let playerWasSetup = false;
 
@@ -134,6 +138,7 @@ export const usePlaying = (): PlayingContextType => {
 };
 
 export const usePlayingProgress = () => useContext(PlayingProgressContext);
+export const usePlayingQueueVersion = () => useContext(PlayingQueueVersionContext);
 
 // Separate component so useProgress ticks don't rerender PlayingProvider.
 const PlayingProgressProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
@@ -934,13 +939,12 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     isPlaying,
     isBuffering,
     currentIndex,
-    queueVersion,
     repeatOn: repeatMode !== 'off',
     repeatMode,
     shuffleMode,
     playbackSpeed,
     setCurrentSong,
-  }), [currentSong, isPlaying, isBuffering, currentIndex, queueVersion, repeatMode, shuffleMode, playbackSpeed]);
+  }), [currentSong, isPlaying, isBuffering, currentIndex, repeatMode, shuffleMode, playbackSpeed]);
 
   // All callbacks are stable (deps are empty or other stable values via refs),
   // so actionsValue almost never changes after mount — action-only consumers
@@ -990,9 +994,11 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   return (
     <PlayingActionsContext.Provider value={actionsValue}>
       <PlayingStateContext.Provider value={stateValue}>
-        <PlayingProgressProvider>
-          {children}
-        </PlayingProgressProvider>
+        <PlayingQueueVersionContext.Provider value={queueVersion}>
+          <PlayingProgressProvider>
+            {children}
+          </PlayingProgressProvider>
+        </PlayingQueueVersionContext.Provider>
       </PlayingStateContext.Provider>
     </PlayingActionsContext.Provider>
   );

--- a/src/contexts/queueProviders.test.ts
+++ b/src/contexts/queueProviders.test.ts
@@ -131,4 +131,22 @@ describe('createAudiomuseQueueFillProvider', () => {
 
     expect(result.map(s => s.id)).toEqual(['a']);
   });
+
+  it('requests a larger candidate pool than count and samples down, so repeat plays of the same seed vary', async () => {
+    const refs = ['a', 'b', 'c', 'd', 'e'].map(id => ({ itemId: id }));
+    (getAudiomuseQueueExtension as jest.Mock).mockResolvedValue(refs);
+    const get = jest.fn(async (id: string) => song(id));
+    const api = fakeApi({ songs: { get, scrobble: jest.fn(), buildStreamUrl: jest.fn() } });
+    const provider = createAudiomuseQueueFillProvider(config, api);
+
+    const result = await provider.fetchExtension({
+      recentSongs: [song('seed')],
+      excludeIds: new Set(),
+      count: 3,
+    });
+
+    const [, opts] = (getAudiomuseQueueExtension as jest.Mock).mock.calls[0];
+    expect(opts.limit).toBeGreaterThan(3);
+    expect(result.length).toBe(3);
+  });
 });

--- a/src/contexts/queueProviders.ts
+++ b/src/contexts/queueProviders.ts
@@ -25,19 +25,26 @@ export function createAudiomuseQueueFillProvider(config: AudiomuseConfig, api: A
     isAvailable: () => Boolean(config.serverUrl && config.apiToken),
     fetchExtension: async ({ recentSongs, excludeIds, count }) => {
       const client = createAudiomuseClient(config);
+      // AudioMuse ranks results deterministically by similarity, so asking
+      // for exactly `count` would return the same tracks in the same order
+      // every time the same seed (e.g. a favorite replayed as the starting
+      // track) comes up. Over-fetch a larger pool and randomly sample from
+      // it — same pattern the native provider uses — so repeat plays vary.
+      const poolSize = Math.max(count * 3, 30);
       const refs = await getAudiomuseQueueExtension(client, {
         seedItemIds: recentSongs.map(s => s.id),
         excludeItemIds: [...excludeIds],
-        limit: count,
+        limit: poolSize,
       });
       // AudioMuse returns track references keyed to the active media server's
       // native item ids, not full Song objects — resolve each one, dropping
       // any that fail rather than failing the whole batch.
       const resolved = await Promise.allSettled(refs.map(ref => api.songs.get(ref.itemId)));
-      return resolved
+      const songs = resolved
         .filter((r): r is PromiseFulfilledResult<Song | null> => r.status === 'fulfilled')
         .map(r => r.value)
         .filter((s): s is Song => s !== null && !excludeIds.has(s.id));
+      return shuffleArray(songs).slice(0, count);
     },
   };
 }

--- a/src/screens/playing/components/Controls.tsx
+++ b/src/screens/playing/components/Controls.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { Shuffle, Sparkles, SkipBack, SkipForward, Repeat, Repeat1, Play, Pause } from 'lucide-react-native';
+import { Shuffle, Sparkle, SkipBack, SkipForward, Repeat, Repeat1, Play, Pause } from 'lucide-react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -42,12 +42,14 @@ function PlayPauseButton({ isPlaying, isBuffering, onPress }: { isPlaying: boole
   );
 }
 
+type ToggleBadge = 'none' | 'dot' | 'sparkle';
+
 function ToggleButton({
-  active,
+  badge,
   onPress,
   children,
 }: {
-  active: boolean;
+  badge: ToggleBadge;
   onPress: () => void;
   children: React.ReactNode;
 }) {
@@ -56,7 +58,8 @@ function ToggleButton({
       <TouchableOpacity onPress={onPress} hitSlop={HIT_SLOP}>
         {children}
       </TouchableOpacity>
-      <View style={[styles.activeDot, active && styles.activeDotVisible]} />
+      {badge === 'dot' && <View style={[styles.activeDot, styles.activeDotVisible]} />}
+      {badge === 'sparkle' && <Sparkle size={9} color="#fff" fill="#fff" style={styles.activeBadge} />}
     </View>
   );
 }
@@ -72,11 +75,11 @@ const Controls: React.FC = () => {
 
   return (
     <View style={styles.container}>
-      <ToggleButton active={shuffleMode !== 'off'} onPress={cycleShuffleMode}>
-        {shuffleMode === 'smart'
-          ? <Sparkles size={23} color="#fff" />
-          : <Shuffle size={23} color="#fff" />
-        }
+      <ToggleButton
+        badge={shuffleMode === 'smart' ? 'sparkle' : shuffleMode === 'shuffle' ? 'dot' : 'none'}
+        onPress={cycleShuffleMode}
+      >
+        <Shuffle size={23} color="#fff" />
       </ToggleButton>
 
       <TouchableOpacity onPress={skipToPrevious} hitSlop={HIT_SLOP}>
@@ -89,7 +92,7 @@ const Controls: React.FC = () => {
         <SkipForward size={34} color="#fff" fill="#fff" />
       </TouchableOpacity>
 
-      <ToggleButton active={repeatMode !== 'off'} onPress={toggleRepeat}>
+      <ToggleButton badge={repeatMode !== 'off' ? 'dot' : 'none'} onPress={toggleRepeat}>
         {repeatMode === 'one'
           ? <Repeat1 size={23} color="#fff" />
           : <Repeat size={23} color="#fff" />
@@ -130,6 +133,10 @@ const styles = StyleSheet.create({
   },
   activeDotVisible: {
     backgroundColor: '#fff',
+  },
+  activeBadge: {
+    position: 'absolute',
+    bottom: -5,
   },
 });
 

--- a/src/screens/playing/components/Queue.tsx
+++ b/src/screens/playing/components/Queue.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import { GripVertical, ChevronLeft, Pause, Play, SkipForward } from 'lucide-react-native';
-import { usePlayingState, usePlayingActions } from '@/contexts/PlayingContext';
+import { usePlayingState, usePlayingActions, usePlayingQueueVersion } from '@/contexts/PlayingContext';
 import { MediaImage } from '@/components/MediaImage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
@@ -75,8 +75,9 @@ const Queue: React.FC<{ onBack: () => void; width: number }> = ({
   width,
 }) => {
   const { t } = useTranslation();
-  const { currentSong, isPlaying, queueVersion } = usePlayingState();
+  const { currentSong, isPlaying } = usePlayingState();
   const { getQueue, skipTo, moveTrack, pauseSong, resumeSong, skipToNext } = usePlayingActions();
+  const queueVersion = usePlayingQueueVersion();
 
   const albumsById = useSelector(selectAlbumsById);
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
## Summary
- **Smart Shuffle / Autoplay**: AudioMuse-AI's similarity API ranks results deterministically, and the queue-fill provider asked for exactly as many candidates as it needed, so replaying the same seed track always produced the identical extension. Now over-fetches a larger candidate pool and randomly samples down to count, matching the pattern the native-similarity provider already uses.
- **Playing screen open/close lag**: `queueVersion` (bumped on every queue mutation — add to queue, play next, reorder, autoplay-fill) was bundled into the same memoized state object as `currentSong`/`isPlaying`/etc., so *every* `usePlayingState()` consumer re-rendered on every queue mutation, even though only the queue list itself reads `queueVersion`. That includes `PlayingBarBase` (mounted on every screen) and the full-screen player's content (mounted the entire time a song is playing, hidden behind the collapsed sheet) — a lot of avoidable reconciliation work competing for the JS thread right as the sheet's open/close animation runs. Split `queueVersion` into its own context, mirroring the existing `PlayingProgressContext` split (added for the same reason, for playback position).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx jest --ci` — 139 tests passing (30 suites)

## Related issues
Follow-up to #172/#173.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3mnXvMuRSrd1sPugbnrKQ)_