### PR TITLE
Fix Lidarr album identity resolution

### DIFF
--- a/src/api/lidarr/albums/index.test.ts
+++ b/src/api/lidarr/albums/index.test.ts
@@ -1,0 +1,408 @@
+import type { ExternalAlbumBase } from '@/types';
+
+import {
+  albumRequestFromExternal,
+  downloadAlbum,
+  resolveAlbumCandidate,
+  resolveArtistCandidate,
+} from './index';
+import type {
+  LidarrAlbum,
+  LidarrAlbumRequest,
+} from './index';
+import type { LidarrArtistLookupResult } from '../artists';
+
+const iveCandidates: LidarrArtistLookupResult[] = [
+  {
+    artistName: 'IVE',
+    foreignArtistId: 'a92e9703-929f-45bb-aa78-b78dfde731a4',
+    disambiguation: 'Ivan Lins - Joana dos Barcos',
+  },
+  {
+    artistName: 'Ive',
+    foreignArtistId: '825c46c4-d5a1-4ed2-8411-6d949b2207cc',
+    disambiguation: 'US Rapper',
+  },
+  {
+    artistName: 'IVE',
+    foreignArtistId: 'a760a4d1-1258-4833-9ed5-fa083902d907',
+    disambiguation: 'German rapper',
+  },
+  {
+    artistName: 'IVE',
+    foreignArtistId: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196',
+    disambiguation: 'South Korean girl group',
+    links: [
+      {
+        name: 'deezer',
+        url: 'https://www.deezer.com/artist/153042292',
+      },
+    ],
+  },
+];
+
+const kanyeCandidates: LidarrArtistLookupResult[] = [
+  {
+    artistName: 'Kanye West Tribute Band',
+    foreignArtistId: '0eb17834-1d29-47ef-a422-9dc68d73c5e4',
+  },
+  {
+    artistName: 'Ye',
+    foreignArtistId: '164f0d73-1234-4e2c-8743-d77bf2191051',
+    disambiguation: 'formerly Kanye West',
+    links: [
+      {
+        name: 'deezer',
+        url: 'https://www.deezer.com/artist/230',
+      },
+    ],
+  },
+];
+
+const request = (
+  overrides: Partial<LidarrAlbumRequest> = {}
+): LidarrAlbumRequest => ({
+  albumTitle: 'IVE EMPATHY',
+  artistName: 'IVE',
+  artistDeezerId: '153042292',
+  albumDeezerId: '684058471',
+  releaseDate: '2025-02-03',
+  releaseType: 'album',
+  ...overrides,
+});
+
+describe('albumRequestFromExternal', () => {
+  it('preserves stable album and artist identities from the catalog item', () => {
+    const album: ExternalAlbumBase = {
+      id: '684058471',
+      title: 'IVE EMPATHY',
+      artist: 'IVE',
+      artistMbid: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196',
+      cover: { kind: 'none' },
+      subtext: 'IVE',
+      releaseDate: '2025-02-03',
+      releaseType: 'album',
+      externalIds: {
+        deezerId: '684058471',
+        artistDeezerId: '153042292',
+        mbid: '79fae544-f374-451d-8f3f-1012bd31c519',
+        artistMbid: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196',
+      },
+    };
+
+    expect(albumRequestFromExternal(album)).toEqual({
+      albumTitle: 'IVE EMPATHY',
+      artistName: 'IVE',
+      albumMbid: '79fae544-f374-451d-8f3f-1012bd31c519',
+      artistMbid: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196',
+      albumDeezerId: '684058471',
+      artistDeezerId: '153042292',
+      releaseDate: '2025-02-03',
+      releaseType: 'album',
+    });
+  });
+});
+
+describe('resolveArtistCandidate', () => {
+  it('selects IVE by exact Deezer identity even when it is fourth', () => {
+    const result = resolveArtistCandidate(iveCandidates, request());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe('deezer');
+      expect(result.artist.foreignArtistId).toBe(
+        'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196'
+      );
+    }
+  });
+
+  it('resolves the old Kanye West name to canonical Ye by Deezer identity', () => {
+    const result = resolveArtistCandidate(
+      kanyeCandidates,
+      request({
+        albumTitle: 'JESUS IS KING',
+        artistName: 'Kanye West',
+        artistDeezerId: '230',
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe('deezer');
+      expect(result.artist.artistName).toBe('Ye');
+      expect(result.artist.foreignArtistId).toBe(
+        '164f0d73-1234-4e2c-8743-d77bf2191051'
+      );
+    }
+  });
+
+  it('prefers MBID and rejects a contradictory Deezer identity', () => {
+    const result = resolveArtistCandidate(
+      iveCandidates,
+      request({
+        artistMbid: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196',
+        artistDeezerId: '230',
+      })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'external_identity_mismatch',
+    });
+  });
+
+  it('uses text only when the normalized name has one candidate', () => {
+    const unique = resolveArtistCandidate(
+      [kanyeCandidates[0]],
+      request({
+        artistName: 'Kanye West Tribute Band',
+        artistDeezerId: undefined,
+      })
+    );
+    const ambiguous = resolveArtistCandidate(
+      iveCandidates,
+      request({ artistDeezerId: undefined })
+    );
+
+    expect(unique.ok).toBe(true);
+    if (unique.ok) expect(unique.matchedBy).toBe('name');
+    expect(ambiguous).toEqual({
+      ok: false,
+      code: 'artist_identity_ambiguous',
+    });
+  });
+});
+
+describe('resolveAlbumCandidate', () => {
+  const albums: LidarrAlbum[] = [
+    {
+      id: 10,
+      title: 'JESUS IS KING',
+      foreignAlbumId: 'ee26718c-2633-4278-8718-f3a45a95f20e',
+      artistId: 2,
+      monitored: false,
+      releaseDate: '2019-10-25T00:00:00Z',
+      albumType: 'Album',
+    },
+    {
+      id: 11,
+      title: 'JESUS IS KING',
+      foreignAlbumId: '00000000-0000-0000-0000-000000000000',
+      artistId: 2,
+      monitored: false,
+      releaseDate: '2024-01-01T00:00:00Z',
+      albumType: 'Album',
+    },
+  ];
+
+  it('selects an album by MusicBrainz release-group ID', () => {
+    const result = resolveAlbumCandidate(
+      albums,
+      request({
+        albumTitle: 'Jesus Is King',
+        artistName: 'Kanye West',
+        albumMbid: 'ee26718c-2633-4278-8718-f3a45a95f20e',
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe('mbid');
+      expect(result.album.id).toBe(10);
+    }
+  });
+
+  it('uses release year and type only to disambiguate equal titles', () => {
+    const result = resolveAlbumCandidate(
+      albums,
+      request({
+        albumTitle: 'Jesus Is King',
+        artistName: 'Kanye West',
+        albumMbid: undefined,
+        releaseDate: '2019-10-25',
+        releaseType: 'album',
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.album.id).toBe(10);
+  });
+
+  it('fails closed when equal titles remain ambiguous', () => {
+    const result = resolveAlbumCandidate(
+      albums,
+      request({
+        albumTitle: 'Jesus Is King',
+        artistName: 'Kanye West',
+        albumMbid: undefined,
+        releaseDate: undefined,
+        releaseType: undefined,
+      })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'album_identity_ambiguous',
+    });
+  });
+});
+
+describe('downloadAlbum', () => {
+  const config = {
+    serverUrl: 'https://lidarr.example',
+    apiKey: 'test-key',
+  };
+  const resolvedArtist = {
+    ...iveCandidates[3],
+    artistType: 'Group',
+  };
+  const lidarrAlbum: LidarrAlbum = {
+    id: 10,
+    title: 'IVE EMPATHY',
+    foreignAlbumId: '79fae544-f374-451d-8f3f-1012bd31c519',
+    artistId: 20,
+    monitored: false,
+    releaseDate: '2025-02-03T00:00:00Z',
+    albumType: 'Album',
+  };
+
+  const response = (body: unknown, status = 200) =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Promise<Response>;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates an unmonitored artist, monitors one album, and submits one search', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response(iveCandidates))
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([{ path: '/music' }]))
+      .mockImplementationOnce(() => response({ id: 20 }))
+      .mockImplementationOnce(() => response([lidarrAlbum]))
+      .mockImplementationOnce(() =>
+        response({ ...lidarrAlbum, monitored: true })
+      )
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response({ id: 30 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await downloadAlbum(config, request());
+
+    expect(result).toEqual({ success: true, status: 'submitted' });
+
+    const calls = fetchMock.mock.calls as [string, RequestInit][];
+    const artistCreate = calls.find(
+      ([url, options]) =>
+        url.endsWith('/artist') && options?.method === 'POST'
+    );
+    expect(JSON.parse(String(artistCreate?.[1].body))).toMatchObject({
+      foreignArtistId: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196',
+      monitored: false,
+      addOptions: {
+        searchForMissingAlbums: false,
+      },
+    });
+
+    const albumUpdate = calls.find(
+      ([url, options]) =>
+        url.endsWith('/album/10') && options?.method === 'PUT'
+    );
+    expect(JSON.parse(String(albumUpdate?.[1].body))).toMatchObject({
+      id: 10,
+      monitored: true,
+    });
+
+    const searches = calls.filter(([url, options]) => {
+      if (!url.endsWith('/command') || options?.method !== 'POST') return false;
+      return JSON.parse(String(options.body)).name === 'AlbumSearch';
+    });
+    expect(searches).toHaveLength(1);
+    expect(JSON.parse(String(searches[0][1].body))).toEqual({
+      name: 'AlbumSearch',
+      albumIds: [10],
+    });
+    expect(calls.some(([, options]) => options?.method === 'DELETE')).toBe(
+      false
+    );
+  });
+
+  it('coalesces simultaneous requests in the same client', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response(iveCandidates))
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response([{ path: '/music' }]))
+      .mockImplementationOnce(() => response({ id: 20 }))
+      .mockImplementationOnce(() => response([lidarrAlbum]))
+      .mockImplementationOnce(() =>
+        response({ ...lidarrAlbum, monitored: true })
+      )
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response({ id: 30 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const first = downloadAlbum(config, request());
+    const second = downloadAlbum(config, request());
+
+    expect(first).toBe(second);
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { success: true, status: 'submitted' },
+      { success: true, status: 'submitted' },
+    ]);
+
+    const commandPosts = fetchMock.mock.calls.filter(
+      ([url, options]) =>
+        String(url).endsWith('/command') &&
+        (options as RequestInit)?.method === 'POST'
+    );
+    expect(commandPosts).toHaveLength(1);
+  });
+
+  it('does not submit a duplicate search already active in Lidarr', async () => {
+    const localArtist = {
+      ...resolvedArtist,
+      id: 20,
+      monitored: false,
+    };
+    const fetchMock = jest
+      .fn()
+      .mockImplementationOnce(() => response([localArtist]))
+      .mockImplementationOnce(() => response([localArtist]))
+      .mockImplementationOnce(() =>
+        response([{ ...lidarrAlbum, monitored: true }])
+      )
+      .mockImplementationOnce(() =>
+        response([
+          {
+            name: 'AlbumSearch',
+            status: 'started',
+            body: { albumIds: [10] },
+          },
+        ])
+      );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await downloadAlbum(config, request());
+
+    expect(result).toEqual({
+      success: true,
+      status: 'already_processing',
+      message: 'Album request is already processing',
+    });
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, options]) =>
+          String(url).endsWith('/command') &&
+          (options as RequestInit)?.method === 'POST'
+      )
+    ).toBe(false);
+  });
+});

--- a/src/api/lidarr/albums/index.ts
+++ b/src/api/lidarr/albums/index.ts
@@ -1,36 +1,401 @@
 import { createLidarrClient, type LidarrClient } from '../client';
 import {
-  lookupArtist,
   ensureArtist,
-  deleteArtist,
+  getArtists,
+  lookupArtist,
+  type LidarrArtistLookupResult,
 } from '../artists';
-import { LidarrConfig } from '@/types';
+import type { ExternalAlbumBase, LidarrConfig } from '@/types';
+
+export type LidarrAlbumErrorCode =
+  | 'missing_album_identity'
+  | 'artist_identity_unresolved'
+  | 'artist_identity_ambiguous'
+  | 'external_identity_mismatch'
+  | 'album_not_found_for_artist'
+  | 'album_identity_ambiguous'
+  | 'lidarr_metadata_unavailable'
+  | 'request_timeout';
+
+export type LidarrAlbumRequest = {
+  albumTitle: string;
+  artistName: string;
+  albumMbid?: string | null;
+  artistMbid?: string | null;
+  albumDeezerId?: string;
+  artistDeezerId?: string;
+  releaseDate?: string;
+  releaseType?: 'album' | 'single';
+};
+
+export type LidarrAlbum = {
+  id: number;
+  title: string;
+  foreignAlbumId?: string;
+  artistId: number;
+  monitored?: boolean;
+  releaseDate?: string;
+  albumType?: string;
+  statistics?: {
+    percentOfTracks?: number;
+    trackFileCount?: number;
+    totalTrackCount?: number;
+  };
+  [key: string]: unknown;
+};
+
+type ArtistResolution =
+  | {
+      ok: true;
+      artist: LidarrArtistLookupResult;
+      matchedBy: 'mbid' | 'deezer' | 'name';
+    }
+  | {
+      ok: false;
+      code:
+        | 'artist_identity_unresolved'
+        | 'artist_identity_ambiguous'
+        | 'external_identity_mismatch';
+    };
+
+type AlbumResolution =
+  | {
+      ok: true;
+      album: LidarrAlbum;
+      matchedBy: 'mbid' | 'title' | 'release';
+    }
+  | {
+      ok: false;
+      code: 'album_not_found_for_artist' | 'album_identity_ambiguous';
+    };
+
+export type AlbumSearchResult =
+  | {
+      success: true;
+      status: 'submitted' | 'already_processing' | 'already_available';
+      message?: string;
+    }
+  | {
+      success: false;
+      code: LidarrAlbumErrorCode;
+      message: string;
+    };
+
+type DownloadOptions = {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  signal?: AbortSignal;
+};
+
+type LidarrCommand = {
+  name?: string;
+  status?: string;
+  albumIds?: number[];
+  body?: {
+    albumIds?: number[];
+  };
+};
+
+const pendingRequests = new Map<string, Promise<AlbumSearchResult>>();
+
+const errorMessages: Record<LidarrAlbumErrorCode, string> = {
+  missing_album_identity: 'Missing album or artist identity',
+  artist_identity_unresolved: 'Artist identity could not be resolved',
+  artist_identity_ambiguous: 'Artist identity is ambiguous',
+  external_identity_mismatch: 'External artist identities disagree',
+  album_not_found_for_artist: 'Album not found for the resolved artist',
+  album_identity_ambiguous: 'Album identity is ambiguous',
+  lidarr_metadata_unavailable: 'Lidarr metadata is unavailable',
+  request_timeout: 'Timed out while waiting for Lidarr metadata',
+};
+
+function failure(code: LidarrAlbumErrorCode): AlbumSearchResult {
+  return {
+    success: false,
+    code,
+    message: errorMessages[code],
+  };
+}
 
 const normalize = (value: string) =>
   value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
-    .replace(/[^a-z0-9]/gi, '')
+    .replace(/[^a-z0-9]/g, '')
     .trim();
 
-type LidarrAlbum = {
-  id: number;
-  title: string;
-  artistId: number;
-};
+const cleanId = (value?: string | null) => value?.trim().toLowerCase() || undefined;
 
-type AlbumSearchResult =
-  | { success: true }
-  | { success: false; message: string };
+function deezerArtistIds(artist: LidarrArtistLookupResult): string[] {
+  const ids = new Set<string>();
+  for (const link of artist.links ?? []) {
+    if (!link.url) continue;
+    const match = link.url.match(
+      /^https?:\/\/(?:www\.)?deezer\.com\/(?:[a-z]{2}\/)?artist\/(\d+)(?:[/?#]|$)/i
+    );
+    if (match?.[1]) ids.add(match[1]);
+  }
+  return [...ids];
+}
 
-async function getAllArtists(client: LidarrClient) {
-  return client.request<any[]>('/artist');
+function sameArtist(
+  left: LidarrArtistLookupResult,
+  right: LidarrArtistLookupResult
+) {
+  return cleanId(left.foreignArtistId) === cleanId(right.foreignArtistId);
+}
+
+export function albumRequestFromExternal(
+  album: ExternalAlbumBase
+): LidarrAlbumRequest {
+  return {
+    albumTitle: album.title,
+    artistName: album.artist,
+    albumMbid: album.externalIds?.mbid,
+    artistMbid: album.artistMbid ?? album.externalIds?.artistMbid,
+    albumDeezerId: album.externalIds?.deezerId,
+    artistDeezerId: album.externalIds?.artistDeezerId,
+    releaseDate: album.releaseDate,
+    releaseType: album.releaseType,
+  };
+}
+
+export function resolveArtistCandidate(
+  candidates: LidarrArtistLookupResult[],
+  request: LidarrAlbumRequest
+): ArtistResolution {
+  const artistMbid = cleanId(request.artistMbid);
+  const artistDeezerId = cleanId(request.artistDeezerId);
+
+  if (artistMbid) {
+    const mbidMatches = candidates.filter(
+      candidate => cleanId(candidate.foreignArtistId) === artistMbid
+    );
+    if (mbidMatches.length > 1) {
+      return { ok: false, code: 'artist_identity_ambiguous' };
+    }
+    if (mbidMatches.length === 1) {
+      const artist = mbidMatches[0];
+      if (artistDeezerId) {
+        const candidateDeezerIds = deezerArtistIds(artist);
+        const anotherDeezerMatch = candidates.some(
+          candidate =>
+            !sameArtist(candidate, artist) &&
+            deezerArtistIds(candidate).includes(artistDeezerId)
+        );
+        if (
+          anotherDeezerMatch ||
+          (candidateDeezerIds.length > 0 &&
+            !candidateDeezerIds.includes(artistDeezerId))
+        ) {
+          return { ok: false, code: 'external_identity_mismatch' };
+        }
+      }
+      return { ok: true, artist, matchedBy: 'mbid' };
+    }
+
+    if (
+      artistDeezerId &&
+      candidates.some(candidate =>
+        deezerArtistIds(candidate).includes(artistDeezerId)
+      )
+    ) {
+      return { ok: false, code: 'external_identity_mismatch' };
+    }
+    return { ok: false, code: 'artist_identity_unresolved' };
+  }
+
+  if (artistDeezerId) {
+    const deezerMatches = candidates.filter(candidate =>
+      deezerArtistIds(candidate).includes(artistDeezerId)
+    );
+    if (deezerMatches.length === 1) {
+      return {
+        ok: true,
+        artist: deezerMatches[0],
+        matchedBy: 'deezer',
+      };
+    }
+    if (deezerMatches.length > 1) {
+      return { ok: false, code: 'artist_identity_ambiguous' };
+    }
+  }
+
+  const normalizedArtist = normalize(request.artistName);
+  const nameMatches = candidates.filter(
+    candidate => normalize(candidate.artistName) === normalizedArtist
+  );
+
+  if (
+    artistDeezerId &&
+    nameMatches.some(candidate => deezerArtistIds(candidate).length > 0)
+  ) {
+    return { ok: false, code: 'external_identity_mismatch' };
+  }
+  if (nameMatches.length === 1) {
+    return { ok: true, artist: nameMatches[0], matchedBy: 'name' };
+  }
+  if (nameMatches.length > 1) {
+    return { ok: false, code: 'artist_identity_ambiguous' };
+  }
+  return { ok: false, code: 'artist_identity_unresolved' };
+}
+
+function releaseYear(value?: string) {
+  const match = value?.match(/^(\d{4})/);
+  return match?.[1];
+}
+
+function matchesReleaseType(album: LidarrAlbum, type: 'album' | 'single') {
+  const albumType = normalize(album.albumType ?? '');
+  if (type === 'single') {
+    return albumType === 'single' || albumType === 'ep';
+  }
+  return albumType === 'album';
+}
+
+export function resolveAlbumCandidate(
+  albums: LidarrAlbum[],
+  request: LidarrAlbumRequest
+): AlbumResolution {
+  const albumMbid = cleanId(request.albumMbid);
+  if (albumMbid) {
+    const matches = albums.filter(
+      album => cleanId(album.foreignAlbumId) === albumMbid
+    );
+    if (matches.length === 1) {
+      return { ok: true, album: matches[0], matchedBy: 'mbid' };
+    }
+    return {
+      ok: false,
+      code:
+        matches.length > 1
+          ? 'album_identity_ambiguous'
+          : 'album_not_found_for_artist',
+    };
+  }
+
+  const normalizedAlbum = normalize(request.albumTitle);
+  let matches = albums.filter(
+    album => normalize(album.title) === normalizedAlbum
+  );
+  if (matches.length === 0) {
+    return { ok: false, code: 'album_not_found_for_artist' };
+  }
+  if (matches.length === 1) {
+    return { ok: true, album: matches[0], matchedBy: 'title' };
+  }
+
+  const year = releaseYear(request.releaseDate);
+  if (year) {
+    matches = matches.filter(album => releaseYear(album.releaseDate) === year);
+  }
+  if (request.releaseType && matches.length > 1) {
+    matches = matches.filter(album =>
+      matchesReleaseType(album, request.releaseType!)
+    );
+  }
+
+  if (matches.length === 1) {
+    return { ok: true, album: matches[0], matchedBy: 'release' };
+  }
+  return {
+    ok: false,
+    code:
+      matches.length === 0
+        ? 'album_not_found_for_artist'
+        : 'album_identity_ambiguous',
+  };
 }
 
 async function getAlbumsByArtist(client: LidarrClient, artistId: number) {
   return client.request<LidarrAlbum[]>(`/album?artistId=${artistId}`);
 }
 
+async function lookupResolvedArtist(
+  client: LidarrClient,
+  request: LidarrAlbumRequest
+): Promise<ArtistResolution> {
+  const localArtists = await getArtists(client);
+  const localResolution = resolveArtistCandidate(localArtists, request);
+  if (localResolution.ok) return localResolution;
+
+  const byName = await lookupArtist(client, request.artistName);
+  let candidates = byName;
+  if (request.artistMbid) {
+    const byMbid = await lookupArtist(client, `lidarr:${request.artistMbid}`);
+    const seen = new Set(byName.map(artist => artist.foreignArtistId));
+    candidates = [
+      ...byName,
+      ...byMbid.filter(artist => !seen.has(artist.foreignArtistId)),
+    ];
+  }
+  return resolveArtistCandidate(candidates, request);
+}
+
+async function waitForAlbum(
+  client: LidarrClient,
+  artistId: number,
+  request: LidarrAlbumRequest,
+  {
+    timeoutMs = 90_000,
+    pollIntervalMs = 2_500,
+    signal,
+  }: DownloadOptions
+): Promise<AlbumResolution | { ok: false; code: 'request_timeout' }> {
+  const started = Date.now();
+
+  while (Date.now() - started < timeoutMs) {
+    if (signal?.aborted) {
+      return { ok: false, code: 'request_timeout' };
+    }
+
+    const albums = await getAlbumsByArtist(client, artistId);
+    const resolution = resolveAlbumCandidate(albums, request);
+    if (resolution.ok || resolution.code === 'album_identity_ambiguous') {
+      return resolution;
+    }
+
+    await delay(pollIntervalMs, signal);
+  }
+
+  return { ok: false, code: 'request_timeout' };
+}
+
+async function monitorAlbum(client: LidarrClient, album: LidarrAlbum) {
+  if (album.monitored) return album;
+  return client.request<LidarrAlbum>(`/album/${album.id}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      ...album,
+      monitored: true,
+    }),
+  });
+}
+
+function commandAlbumIds(command: LidarrCommand) {
+  return command.albumIds ?? command.body?.albumIds ?? [];
+}
+
+async function hasActiveAlbumSearch(
+  client: LidarrClient,
+  albumId: number
+) {
+  const commands = await client.request<LidarrCommand[]>('/command');
+  return commands.some(command => {
+    const status = command.status?.toLowerCase();
+    return (
+      command.name?.toLowerCase() === 'albumsearch' &&
+      (status === 'queued' || status === 'started') &&
+      commandAlbumIds(command).includes(albumId)
+    );
+  });
+}
+
 async function triggerAlbumSearch(client: LidarrClient, albumId: number) {
+  if (await hasActiveAlbumSearch(client, albumId)) return false;
+
   await client.request('/command', {
     method: 'POST',
     body: JSON.stringify({
@@ -38,116 +403,112 @@ async function triggerAlbumSearch(client: LidarrClient, albumId: number) {
       albumIds: [albumId],
     }),
   });
+  return true;
 }
 
-export async function downloadAlbum(
-  config: LidarrConfig,
-  albumTitle: string,
-  artistName: string
-): Promise<AlbumSearchResult> {
-  if (!albumTitle || !artistName) {
-    return { success: false, message: 'Missing album or artist name' };
-  }
+function isAlbumAvailable(album: LidarrAlbum) {
+  const statistics = album.statistics;
+  if (!statistics) return false;
+  if ((statistics.percentOfTracks ?? 0) >= 100) return true;
+  return (
+    (statistics.totalTrackCount ?? 0) > 0 &&
+    statistics.trackFileCount === statistics.totalTrackCount
+  );
+}
 
-  const client = createLidarrClient(config);
-  const normalizedAlbum = normalize(albumTitle);
-  const normalizedArtist = normalize(artistName);
+function requestKey(request: LidarrAlbumRequest) {
+  const artist =
+    cleanId(request.artistMbid) ??
+    cleanId(request.artistDeezerId) ??
+    normalize(request.artistName);
+  const album =
+    cleanId(request.albumMbid) ??
+    cleanId(request.albumDeezerId) ??
+    `${normalize(request.albumTitle)}:${releaseYear(request.releaseDate) ?? ''}`;
+  return `${artist}:${album}`;
+}
+
+async function performDownload(
+  config: LidarrConfig,
+  request: LidarrAlbumRequest,
+  options: DownloadOptions
+): Promise<AlbumSearchResult> {
+  if (!request.albumTitle?.trim() || !request.artistName?.trim()) {
+    return failure('missing_album_identity');
+  }
 
   try {
-    const localArtists = await getAllArtists(client);
-    const matchedArtist = localArtists.find(
-      a => normalize(a.artistName) === normalizedArtist
+    const client = createLidarrClient(config);
+    const artistResolution = await lookupResolvedArtist(client, request);
+    if (!artistResolution.ok) return failure(artistResolution.code);
+
+    const ensured = await ensureArtist(client, artistResolution.artist, {
+      monitored: false,
+      searchForMissingAlbums: false,
+    });
+    if (!ensured.success) return failure('lidarr_metadata_unavailable');
+
+    const albumResolution = await waitForAlbum(
+      client,
+      ensured.artistId,
+      request,
+      options
     );
+    if (!albumResolution.ok) return failure(albumResolution.code);
 
-    if (matchedArtist) {
-      const albums = await getAlbumsByArtist(client, matchedArtist.id);
-      const album = albums.find(
-        a => normalize(a.title) === normalizedAlbum
-      );
-
-      if (album) {
-        await triggerAlbumSearch(client, album.id);
-        return { success: true };
-      }
+    if (isAlbumAvailable(albumResolution.album)) {
+      return {
+        success: true,
+        status: 'already_available',
+        message: 'Album is already available',
+      };
     }
 
-    const lookupResults = await lookupArtist(client, artistName);
-    if (!lookupResults || lookupResults.length === 0) {
-      return { success: false, message: 'Artist not found in lookup' };
-    }
-
-    const candidates = lookupResults
-      .filter(a => normalize(a.artistName) === normalizedArtist)
-      .slice(0, 3);
-
-    for (const candidate of candidates) {
-      const ensured = await ensureArtist(client, candidate, {
-        monitored: false,
-        searchForMissingAlbums: true,
-      });
-
-      if (!ensured.success) continue;
-
-      const artistId = ensured.artistId;
-
-      const album = await waitForAlbum(
-        client,
-        artistId,
-        normalizedAlbum,
-        {
-          timeoutMs: 90_000,
-          pollIntervalMs: 2_500,
-        }
-      );
-
-      if (album) {
-        await triggerAlbumSearch(client, album.id);
-        return { success: true };
-      }
-
-      if (ensured.created) {
-        await deleteArtist(client, artistId);
-      }
-    }
-
-    return {
-      success: false,
-      message: 'Album not found from matched artists',
-    };
-  } catch (e: any) {
-    return {
-      success: false,
-      message: e?.message ?? 'Album download failed',
-    };
+    const album = await monitorAlbum(client, albumResolution.album);
+    const submitted = await triggerAlbumSearch(client, album.id);
+    return submitted
+      ? { success: true, status: 'submitted' }
+      : {
+          success: true,
+          status: 'already_processing',
+          message: 'Album request is already processing',
+        };
+  } catch {
+    return failure(
+      options.signal?.aborted
+        ? 'request_timeout'
+        : 'lidarr_metadata_unavailable'
+    );
   }
 }
 
-async function waitForAlbum(
-  client: LidarrClient,
-  artistId: number,
-  normalizedAlbum: string,
-  {
-    timeoutMs = 60_000,
-    pollIntervalMs = 2_000,
-  } = {}
-): Promise<LidarrAlbum | null> {
-  const started = Date.now();
+export function downloadAlbum(
+  config: LidarrConfig,
+  request: LidarrAlbumRequest,
+  options: DownloadOptions = {}
+): Promise<AlbumSearchResult> {
+  const key = requestKey(request);
+  const pending = pendingRequests.get(key);
+  if (pending) return pending;
 
-  while (Date.now() - started < timeoutMs) {
-    const albums = await getAlbumsByArtist(client, artistId);
-
-    const album = albums.find(
-      a => normalize(a.title) === normalizedAlbum
-    );
-
-    if (album) return album;
-
-    await delay(pollIntervalMs);
-  }
-
-  return null;
+  const operation = performDownload(config, request, options).finally(() => {
+    if (pendingRequests.get(key) === operation) pendingRequests.delete(key);
+  });
+  pendingRequests.set(key, operation);
+  return operation;
 }
 
-function delay(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function delay(ms: number, signal?: AbortSignal) {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise<void>(resolve => {
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true }
+    );
+  });
 }

--- a/src/api/lidarr/artists/index.ts
+++ b/src/api/lidarr/artists/index.ts
@@ -1,6 +1,7 @@
 import type { LidarrClient } from '../client';
 
 export type LidarrArtistLookupResult = {
+  id?: number;
   artistName: string;
   foreignArtistId: string;
   artistType?: string;
@@ -10,13 +11,12 @@ export type LidarrArtistLookupResult = {
   genres?: string[];
   ratings?: any;
   status?: string;
+  monitored?: boolean;
+  links?: { name?: string; url?: string }[];
 };
 
-export type LidarrArtist = {
+export type LidarrArtist = LidarrArtistLookupResult & {
   id: number;
-  artistName: string;
-  foreignArtistId: string;
-  monitored?: boolean;
 };
 
 export type EnsureArtistOptions = {
@@ -103,18 +103,19 @@ export async function ensureArtist(
 
     return { success: true, artistId: created.id, created: true };
   } catch (e: any) {
+    // A different client may have created this artist after our first read.
+    // Lidarr enforces foreignArtistId uniqueness, so re-read and converge.
+    try {
+      const existing = await getArtists(client);
+      const found = existing.find(
+        a => a.foreignArtistId === artist.foreignArtistId
+      );
+      if (found?.id) {
+        return { success: true, artistId: found.id, created: false };
+      }
+    } catch {
+      // Preserve the original error if reconciliation also fails.
+    }
     return { success: false, message: e?.message ?? 'Failed to ensure artist' };
-  }
-}
-
-export async function deleteArtist(
-  client: LidarrClient,
-  artistId: number
-): Promise<{ success: true } | { success: false; message: string }> {
-  try {
-    await client.request(`/artist/${artistId}`, { method: 'DELETE' });
-    return { success: true };
-  } catch (e: any) {
-    return { success: false, message: e?.message ?? 'Failed to delete artist' };
   }
 }

--- a/src/api/lidarr/client.ts
+++ b/src/api/lidarr/client.ts
@@ -25,12 +25,10 @@ export function createLidarrClient(config: LidarrConfig) {
     });
 
     if (!res.ok) {
-      const text = await res.text();
-      throw new Error(
-        `Lidarr API error (${res.status}): ${text}`
-      );
+      throw new Error(`Lidarr API error (${res.status})`);
     }
 
+    if (res.status === 204) return {} as T;
     return res.json();
   }
 

--- a/src/api/lidarr/index.ts
+++ b/src/api/lidarr/index.ts
@@ -19,12 +19,16 @@ export function ensureArtist(
 ) {
   return artists.ensureArtist(createLidarrClient(config), artist, opts);
 }
-export function deleteArtist(config: LidarrConfig, artistId: number) {
-  return artists.deleteArtist(createLidarrClient(config), artistId);
-}
 
 // Albums
-export { downloadAlbum } from './albums';
+export {
+  albumRequestFromExternal,
+  downloadAlbum,
+} from './albums';
+export type {
+  AlbumSearchResult,
+  LidarrAlbumRequest,
+} from './albums';
 
 // Queue
 export {

--- a/src/api/musicbrainz/index.ts
+++ b/src/api/musicbrainz/index.ts
@@ -24,7 +24,7 @@ export type MbReleaseGroup = {
   'primary-type'?: string;
   'secondary-types'?: string[];
   'first-release-date'?: string;
-  'artist-credit'?: { name?: string; artist: { name: string } }[];
+  'artist-credit'?: { name?: string; artist: { id?: string; name: string } }[];
 };
 
 export type MbTrack = {
@@ -33,7 +33,7 @@ export type MbTrack = {
   length: number | null;
   position: number;
   recording?: { id: string };
-  'artist-credit'?: { name?: string; artist: { name: string } }[];
+  'artist-credit'?: { name?: string; artist: { id?: string; name: string } }[];
 };
 
 export type MbRelease = {

--- a/src/components/options/DownloadAlbumSheet.tsx
+++ b/src/components/options/DownloadAlbumSheet.tsx
@@ -52,7 +52,10 @@ const DownloadAlbumSheet: React.FC<Props> = ({ album, sheetRef }) => {
     if (anyLoading) return;
     setLidarrLoading(true);
     try {
-      const result = await lidarr.downloadAlbum(lidarrConfig, album.title, album.artist);
+      const result = await lidarr.downloadAlbum(
+        lidarrConfig,
+        lidarr.albumRequestFromExternal(album)
+      );
       toast[result.success ? 'success' : 'error'](
         result.success
           ? t('externalAlbum.download.addedToLidarr')

--- a/src/features/sources/registry.ts
+++ b/src/features/sources/registry.ts
@@ -98,17 +98,24 @@ function releaseGroupToCover(rg: mb.MbReleaseGroup): CoverSource {
   return { kind: 'coverartarchive', mbid: rg.id, mbidType: 'release-group' }
 }
 
-function releaseGroupToAlbumBase(rg: mb.MbReleaseGroup, fallbackArtist: string): ExternalAlbumBase {
+function releaseGroupToAlbumBase(
+  rg: mb.MbReleaseGroup,
+  fallbackArtist: string,
+  fallbackArtistMbid?: string
+): ExternalAlbumBase {
   const artistName = rg['artist-credit']?.[0]?.artist.name ?? fallbackArtist
+  const artistMbid = rg['artist-credit']?.[0]?.artist.id ?? fallbackArtistMbid ?? null
   return {
     id: rg.id,
     title: rg.title,
     artist: artistName,
+    artistMbid,
     cover: releaseGroupToCover(rg),
     subtext: rg['first-release-date']?.slice(0, 4) ?? '',
+    releaseDate: rg['first-release-date'] ?? undefined,
     releaseType: rg['primary-type']?.toLowerCase() === 'single' ? 'single' : 'album',
     externalSource: 'musicbrainz',
-    externalIds: { mbid: rg.id },
+    externalIds: { mbid: rg.id, artistMbid },
   }
 }
 
@@ -143,6 +150,7 @@ const musicbrainzSource: SourceDefinition = {
       mb.getTracksForReleaseGroup(id),
     ])
     const artistName = rg['artist-credit']?.[0]?.artist.name ?? ''
+    const artistMbid = rg['artist-credit']?.[0]?.artist.id ?? null
     const songs = tracks.map(track => ({
       id: track.recording?.id ?? track.id,
       title: track.title,
@@ -156,10 +164,13 @@ const musicbrainzSource: SourceDefinition = {
       id: rg.id,
       title: rg.title,
       artist: artistName,
+      artistMbid,
       cover: releaseGroupToCover(rg),
       subtext: rg['first-release-date']?.slice(0, 4) ?? '',
+      releaseDate: rg['first-release-date'] ?? undefined,
+      releaseType: rg['primary-type']?.toLowerCase() === 'single' ? 'single' : 'album',
       externalSource: 'musicbrainz',
-      externalIds: { mbid: rg.id },
+      externalIds: { mbid: rg.id, artistMbid },
       songs,
     }
   },
@@ -169,7 +180,7 @@ const musicbrainzSource: SourceDefinition = {
     const rgs = artist['release-groups'] ?? []
     return rgs
       .slice(0, limit)
-      .map(rg => releaseGroupToAlbumBase(rg, artist.name))
+      .map(rg => releaseGroupToAlbumBase(rg, artist.name, artist.id))
   },
 
   async fetchArtist(id) {
@@ -177,10 +188,10 @@ const musicbrainzSource: SourceDefinition = {
     const rgs = artist['release-groups'] ?? []
     const albums = rgs
       .filter(rg => !rg['primary-type'] || rg['primary-type'] === 'Album')
-      .map(rg => releaseGroupToAlbumBase(rg, artist.name))
+      .map(rg => releaseGroupToAlbumBase(rg, artist.name, artist.id))
     const singles = rgs
       .filter(rg => rg['primary-type'] === 'Single' || rg['primary-type'] === 'EP')
-      .map(rg => releaseGroupToAlbumBase(rg, artist.name))
+      .map(rg => releaseGroupToAlbumBase(rg, artist.name, artist.id))
     return {
       id: artist.id,
       name: artist.name,


### PR DESCRIPTION
## Summary

- preserve Deezer/MusicBrainz album and artist IDs when requesting an album
- resolve Lidarr artists and albums by stable identity before textual fallback
- create artists without broad searches, monitor only the selected album, and
  remove destructive timeout cleanup
- coalesce local duplicate requests and reconcile Lidarr uniqueness/active
  command state
- add regression coverage for IVE homonyms and Kanye West/Ye aliases

Closes #177.
Addresses the album-monitoring request in #176.

## Behavior

Artist resolution order:

1. MusicBrainz artist ID
2. exact Deezer artist link ID
3. normalized name only when unique

Album resolution order:

1. MusicBrainz release-group ID
2. unique normalized title under the resolved artist
3. release year/type as tie-breakers

Ambiguous or contradictory identities now fail before mutation. New artists are
created with `monitored=false` and `searchForMissingAlbums=false`; only the
chosen album is monitored and searched.

## Validation

- `npx jest --ci` — 19 suites, 79 tests passed
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`
